### PR TITLE
Fix GitHub Actions for deploying to PyPi

### DIFF
--- a/.github/workflows/deploy-pypi.yml
+++ b/.github/workflows/deploy-pypi.yml
@@ -2,7 +2,7 @@ name: Release to PyPi
 
 on:
   release:
-    types: [published]
+    types: [released]
 
 jobs:
   deploy:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "themefinder"
-version = "0.3.0"
+version = "0.3.1"
 description = "A topic modelling Python package designed for analysing one-to-many question-answer data eg free-text survey responses."
 authors = ["i.AI <packages@cabinetoffice.gov.uk>"]
 packages = [{include = "themefinder", from = "src"}]


### PR DESCRIPTION
Before, releases weren't deploying if we'd created a pre-release first.

Changing the trigger to `release` means that changing from pre-release to release triggers workflow (this has been tested).

Also updating version number for bugfix - intend to create a release imminently.