### PR TITLE
Theme Target Alignment Task

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ ThemeFinder's pipeline consists of five distinct stages, each utilizing a specia
 - Leverages standardisation prompts to normalise theme descriptions
 - Creates clear, consistent theme definitions through structured refinement
 
+### Theme target alignment
+- Optional step to consolidate themes down to a target number
+
 ### Theme mapping
 - Utilizes classification prompts to map individual responses to refined themes
 - Supports multiple theme assignments per response through detailed analysis

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -12,5 +12,7 @@
 
 ::: themefinder.core.theme_refinement
 
+::: themefinder.core.theme_target_alignment
+
 ::: themefinder.core.theme_mapping
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,9 @@ ThemeFinder's pipeline consists of five distinct stages, each utilizing a specia
 - Leverages standardisation prompts to normalise theme descriptions
 - Creates clear, consistent theme definitions through structured refinement
 
+### Theme target alignment
+- Optional step to consolidate themes down to a target number
+
 ### Theme mapping
 - Utilizes classification prompts to map individual responses to refined themes
 - Supports multiple theme assignments per response through detailed analysis

--- a/src/themefinder/prompts/theme_target_alignment.txt
+++ b/src/themefinder/prompts/theme_target_alignment.txt
@@ -1,0 +1,26 @@
+{system_prompt}
+Input: You will receive a JSON array of themes, where each theme contains a description of a topic or concept.
+
+Goal: Consolidate these themes into approximately {target_n_themes} distinct categories by:
+1. Identifying and combining similar or overlapping themes
+2. Preserving all significant details and perspectives
+3. Creating clear, comprehensive descriptions for each merged theme
+
+Requirements:
+- Each consolidated theme should capture all relevant information from its source themes
+- Final descriptions should be concise but thorough
+- The merged themes should be distinct from each other with minimal overlap
+
+Return your output in the following JSON format:
+
+{{
+   "responses": [
+       {{"topic_id": "A", "topic": "{{topic label 1}}: {{topic description 1}}"}},
+       {{"topic_id": "B", "topic": "{{topic label 2}}: {{topic description 2}}"}},
+       {{"topic_id": "C", "topic": "{{topic label 3}}: {{topic description 3}}"}},
+      // Additional topics as necessary
+   ]
+}}
+
+Themes to analyze: 
+{responses}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -20,6 +20,7 @@ async def test_find_themes(mock_llm, sample_df):
             content='{"responses": [{"condensed_themes": ["main_theme1", "main_theme2"]}]}'
         ),
         MagicMock(content='{"responses": [{"topic_id": "label1", "topic": "desc1"}]}'),
+        MagicMock(content='{"responses": [{"topic_id": "label1", "topic": "desc1"}]}'),
         MagicMock(
             content=json.dumps(
                 {
@@ -39,20 +40,22 @@ async def test_find_themes(mock_llm, sample_df):
             )
         ),
     ]
-    result = await find_themes(sample_df, mock_llm, question="test question")
+    result = await find_themes(
+        sample_df, mock_llm, question="test question", target_n_themes=2
+    )
     assert isinstance(result, dict)
     assert all(
         key in result
         for key in [
             "sentiment",
             "topics",
-            "condensed_topics",
+            "condensed_themes",
             "mapping",
             "question",
-            "refined_topics",
+            "refined_themes",
         ]
     )
-    assert mock_llm.ainvoke.call_count == 6
+    assert mock_llm.ainvoke.call_count == 7
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Add a new theme target alignment task to the repo. 

This is a renamed version of @michaelPD-iAI theme crushing prompt. This will be skipped by default in the core pipeline. Motivation for adding it is the recent changes to theme condensation mean that we tend to produce a very large number of topics, this probably makes the tool unusable for most use cases (I found this out first hand while experimenting on an external dataset). This way people have a way of reducing the number if they need.