### PR TITLE
improvements to integrity errors

### DIFF
--- a/src/themefinder/prompts/theme_mapping.txt
+++ b/src/themefinder/prompts/theme_mapping.txt
@@ -10,7 +10,7 @@ You will be given:
         {{'response_id': 'free text response'}}
 
 Your task is to analyze each response and decide which topics are present. Guidelines:
-    - You can only assign a response to a topic in the provided TOPIC LIST
+    - You can only assign to a response to a topic in the provided TOPIC LIST
     - A response doesn't need to exactly match the language used in the TOPIC LIST, it should be considered a match if it expresses a similar sentiment.
     - You must use the alphabetic 'topic_id' to indicate which topic you have assigned.
     - Each response can be assigned to multiple topics if it matches more than one topic from the TOPIC LIST.
@@ -20,6 +20,9 @@ Your task is to analyze each response and decide which topics are present. Guide
     - If a response contains both positive and negative statements about a topic within the same response, choose the stance that receives more emphasis or appears more central to the argument
     - The order of reasons and stances must align with the order of labels (e.g., stance_a applies to topic_a)
 
+You MUST include every response ID in the output.
+If the response can not be labelled return empty sections where appropriate but you MUST return an entry
+with the correct response ID for each input object
 
 The final output should be in the following JSON format:
 


### PR DESCRIPTION
- Change to theme mapping prompt to be stricter about returning the correct format even when the LLM doesn't like the input
- Changed how response integrity failures are handled so only the failures are re-run rather than the whole batch.
- Added optional default themes (Other/No Reason Given) to pipeline code as final step before mapping
- NaN rows are dropped at prompt batch generation