### PR TITLE
Improve naming consistency in logging and prompts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "themefinder"
-version = "0.5.2"
+version = "0.5.3"
 description = "A topic modelling Python package designed for analysing one-to-many question-answer data eg free-text survey responses."
 authors = ["i.AI <packages@cabinetoffice.gov.uk>"]
 packages = [{include = "themefinder", from = "src"}]

--- a/src/themefinder/core.py
+++ b/src/themefinder/core.py
@@ -95,7 +95,7 @@ async def find_themes(
     return {
         "question": question,
         "sentiment": sentiment_df,
-        "topics": theme_df,
+        "themes": theme_df,
         "condensed_themes": condensed_theme_df,
         "refined_themes": refined_theme_df,
         "mapping": mapping_df,
@@ -224,7 +224,7 @@ async def theme_condensation(
         pd.DataFrame: DataFrame containing the condensed themes, where similar topics
             have been combined into broader categories.
     """
-    logger.info(f"Running theme condensation on {len(themes_df)} responses")
+    logger.info(f"Running theme condensation on {len(themes_df)} themes")
     themes_df["response_id"] = range(len(themes_df))
 
     n_themes = themes_df.shape[0]

--- a/src/themefinder/prompts/theme_mapping.txt
+++ b/src/themefinder/prompts/theme_mapping.txt
@@ -12,7 +12,7 @@ You will be given:
 Your task is to analyze each response and decide which topics are present. Guidelines:
     - You can only assign to a response to a topic in the provided TOPIC LIST
     - A response doesn't need to exactly match the language used in the TOPIC LIST, it should be considered a match if it expresses a similar sentiment.
-    - You must use the alphabetic 'topic_id' to indicate which topic you have assigned.
+    - You must use the alphabetic 'topic_id' to indicate which topic you have assigned. Do not use the full topic description
     - Each response can be assigned to multiple topics if it matches more than one topic from the TOPIC LIST.
     - There is no limit on how many topics can be assigned to a response.
     - For each assignment provide a single rationale for why you have chosen the label.
@@ -22,7 +22,8 @@ Your task is to analyze each response and decide which topics are present. Guide
 
 You MUST include every response ID in the output.
 If the response can not be labelled return empty sections where appropriate but you MUST return an entry
-with the correct response ID for each input object
+with the correct response ID for each input object.
+You must only return the alphabetic topic_ids in the labels section.
 
 The final output should be in the following JSON format:
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -48,7 +48,7 @@ async def test_find_themes(mock_llm, sample_df):
         key in result
         for key in [
             "sentiment",
-            "topics",
+            "themes",
             "condensed_themes",
             "mapping",
             "question",


### PR DESCRIPTION
There were a few inconsistent uses of topics still knocking about in the repo. This updates the python version so this can be released