### PR TITLE
Feat/pipeline validation and resilience

### DIFF
--- a/src/themefinder/llm_batch_processor.py
+++ b/src/themefinder/llm_batch_processor.py
@@ -6,12 +6,19 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional, Type
 
+import openai
 import pandas as pd
 import tiktoken
 from langchain_core.prompts import PromptTemplate
 from langchain_core.runnables import Runnable
 from pydantic import BaseModel, ValidationError
-from tenacity import before, retry, stop_after_attempt, wait_random_exponential
+from tenacity import (
+    before,
+    before_sleep_log,
+    retry,
+    stop_after_attempt,
+    wait_random_exponential,
+)
 
 from .themefinder_logging import logger
 
@@ -19,16 +26,17 @@ from .themefinder_logging import logger
 @dataclass
 class BatchPrompt:
     prompt_string: str
-    response_ids: list[str]
+    response_ids: list[int]
 
 
 async def batch_and_run(
-    responses_df: pd.DataFrame,
+    input_df: pd.DataFrame,
     prompt_template: str | Path | PromptTemplate,
     llm: Runnable,
+    task_validation_model: Type[BaseModel] = None,
     batch_size: int = 10,
     partition_key: str | None = None,
-    response_id_integrity_check: bool = False,
+    validation_check: bool = False,
     **kwargs: Any,
 ) -> pd.DataFrame:
     """Process a DataFrame of responses in batches using an LLM.
@@ -43,7 +51,7 @@ async def batch_and_run(
             Defaults to 10.
         partition_key (str | None, optional): Optional column name to group responses
             before batching. Defaults to None.
-        response_id_integrity_check (bool, optional): If True, verifies that all input
+        validation_check (bool, optional): If True, verifies that all input
             response IDs are present in LLM output and retries failed responses individually.
             If False, no integrity checking or retrying occurs. Defaults to False.
         **kwargs (Any): Additional keyword arguments to pass to the prompt template.
@@ -52,30 +60,55 @@ async def batch_and_run(
         pd.DataFrame: DataFrame containing the original responses merged with the
             LLM-processed results.
     """
+
     logger.info(f"Running batch and run with batch size {batch_size}")
     prompt_template = convert_to_prompt_template(prompt_template)
     batch_prompts = generate_prompts(
-        prompt_template, responses_df, batch_size=batch_size, **kwargs
+        prompt_template,
+        input_df,
+        batch_size=batch_size,
+        partition_key=partition_key,
+        **kwargs,
     )
-    llm_responses, failed_ids = await call_llm(
+    processed_rows, failed_ids = await call_llm(
         batch_prompts=batch_prompts,
         llm=llm,
-        response_id_integrity_check=response_id_integrity_check,
+        validation_check=validation_check,
+        task_validation_model=task_validation_model,
     )
-    processed_responses = process_llm_responses(llm_responses, responses_df)
-    if failed_ids and response_id_integrity_check:
-        new_df = responses_df[responses_df["response_id"].astype(str).isin(failed_ids)]
-        processed_failed_responses = await batch_and_run(
-            responses_df=new_df,
-            prompt_template=prompt_template,
-            llm=llm,
-            batch_size=1,
-            partition_key=partition_key,
-            response_id_integrity_check=False,
-            **kwargs,
+    processed_results = process_llm_responses(processed_rows, input_df)
+
+    if failed_ids:
+        retry_df = input_df[input_df["response_id"].isin(failed_ids)]
+        retry_prompts = generate_prompts(
+            prompt_template, retry_df, batch_size=1, **kwargs
         )
-        return pd.concat(objs=[processed_failed_responses, processed_responses])
-    return processed_responses
+        retry_results, unprocessable_ids = await call_llm(
+            batch_prompts=retry_prompts,
+            llm=llm,
+            validation_check=validation_check,
+            task_validation_model=task_validation_model,
+        )
+        retry_processed_results = process_llm_responses(retry_results, retry_df)
+        unprocessable_df = retry_df.loc[retry_df["response_id"].isin(unprocessable_ids)]
+        processed_results = pd.concat([processed_results, retry_processed_results])
+    else:
+        unprocessable_df = pd.DataFrame()
+    return processed_results, unprocessable_df
+
+
+def batch_task_inputs(
+    input_data: pd.DataFrame,
+    prompt_template: PromptTemplate,
+    batch_size: int = 50,
+    **kwargs,
+) -> list[BatchPrompt]:
+    prompt_template = convert_to_prompt_template(prompt_template)
+    batch_prompts = generate_prompts(
+        prompt_template, input_data, batch_size=batch_size, **kwargs
+    )
+
+    return batch_prompts
 
 
 def load_prompt_from_file(file_path: str | Path) -> str:
@@ -226,12 +259,10 @@ def generate_prompts(
     """
     prompt_token_length = calculate_string_token_length(prompt_template.template)
     allowed_tokens_for_data = max_prompt_length - prompt_token_length
-
-    all_batches = batch_task_input_df(
+    batches = batch_task_input_df(
         input_data, allowed_tokens_for_data, batch_size, partition_key
     )
-    prompts = [build_prompt(prompt_template, batch, **kwargs) for batch in all_batches]
-
+    prompts = [build_prompt(prompt_template, batch, **kwargs) for batch in batches]
     return prompts
 
 
@@ -239,8 +270,9 @@ async def call_llm(
     batch_prompts: list[BatchPrompt],
     llm: Runnable,
     concurrency: int = 10,
-    response_id_integrity_check: bool = False,
-):
+    validation_check: bool = False,
+    task_validation_model: Type[BaseModel] = None,
+) -> tuple[list[dict], list[int]]:
     """Process multiple batches of prompts concurrently through an LLM with retry logic.
 
     Args:
@@ -249,7 +281,7 @@ async def call_llm(
         llm (Runnable): LangChain Runnable instance that will process the prompts.
         concurrency (int, optional): Maximum number of simultaneous LLM calls allowed.
             Defaults to 10.
-        response_id_integrity_check (bool, optional): If True, verifies that all input
+        response_id_validation_check (bool, optional): If True, verifies that all input
             response IDs are present in the LLM output. Failed batches are discarded and
             their IDs are returned for retry. Defaults to False.
 
@@ -269,72 +301,71 @@ async def call_llm(
         wait=wait_random_exponential(min=1, max=20),
         stop=stop_after_attempt(6),
         before=before.before_log(logger=logger, log_level=logging.DEBUG),
+        before_sleep=before_sleep_log(logger, logging.ERROR),
         reraise=True,
     )
-    async def async_llm_call(batch_prompt):
+    async def async_llm_call(batch_prompt) -> tuple[list[dict], list[int]]:
         async with semaphore:
-            response = await llm.ainvoke(batch_prompt.prompt_string)
-            parsed_response = json.loads(response.content)
-            failed_ids: set = set()
+            try:
+                llm_response = await llm.ainvoke(batch_prompt.prompt_string)
+                all_results = json.loads(llm_response.content)
+            except (openai.BadRequestError, json.JSONDecodeError) as e:
+                failed_ids = batch_prompt.response_ids
+                logger.warning(e)
+                return [], failed_ids
 
-            if response_id_integrity_check and not check_response_integrity(
-                batch_prompt.response_ids, parsed_response
-            ):
-                # discard this response but keep track of failed response ids
-                failed_ids.update(batch_prompt.response_ids)
-                return {"response": None, "failed_ids": failed_ids}
-
-            return {"response": parsed_response, "failed_ids": failed_ids}
+            if validation_check:
+                failed_ids = get_missing_response_ids(
+                    batch_prompt.response_ids, all_results
+                )
+                validated_results, invalid_rows = validate_task_data(
+                    all_results["responses"], task_validation_model
+                )
+                failed_ids.extend([r["response_id"] for r in invalid_rows])
+                return validated_results, failed_ids
+            else:
+                # Flatten the list to align with valid output format
+                return [r for r in all_results["responses"]], []
 
     results = await asyncio.gather(
         *[async_llm_call(batch_prompt) for batch_prompt in batch_prompts]
     )
+    valid_inputs = [row for result, _ in results for row in result]
+    failed_response_ids = [
+        failed_response_id
+        for _, batch_failures in results
+        for failed_response_id in batch_failures
+    ]
 
-    # Extract responses
-    successful_responses = [
-        r["response"] for r in results if r["response"] is not None
-    ]  # ignore discarded responses
-
-    # Extract failed ids
-    failed_ids: set = set()
-    for r in results:
-        if r["response"] is None:
-            failed_ids.update(r["failed_ids"])
-    return (successful_responses, failed_ids)
+    return valid_inputs, failed_response_ids
 
 
-def check_response_integrity(
-    input_response_ids: set[str], parsed_response: dict
-) -> bool:
-    """Verify that all input response IDs are present in the LLM's parsed response.
+def get_missing_response_ids(
+    input_response_ids: list[int], parsed_response: dict
+) -> set[int]:
+    """Identify which response IDs are missing from the LLM's parsed response.
 
     Args:
         input_response_ids (set[str]): Set of response IDs that were included in the
-            original prompt sent to the LLM.
+            original prompt.
         parsed_response (dict): Parsed response from the LLM containing a 'responses' key
             with a list of dictionaries, each containing a 'response_id' field.
 
     Returns:
-        bool: True if all input response IDs are present in the parsed response and
-            no additional IDs are present, False otherwise.
+        set[str]: Set of response IDs that are missing from the parsed response.
     """
-    response_ids_set = set(input_response_ids)
 
+    response_ids_set = {int(response_id) for response_id in input_response_ids}
     returned_ids_set = {
-        str(
-            element["response_id"]
-        )  # treat ids as strings to match response_ids_in_each_prompt
+        int(element["response_id"])
         for element in parsed_response["responses"]
         if element.get("response_id", False)
     }
-    # assumes: all input ids ought to be present in output
-    if returned_ids_set != response_ids_set:
-        logger.info("Failed integrity check")
-        logger.info(
-            f"Present in original but not returned from LLM: {response_ids_set - returned_ids_set}. Returned in LLM but not present in original: {returned_ids_set - response_ids_set}"
-        )
-        return False
-    return True
+
+    missing_ids = list(response_ids_set - returned_ids_set)
+    if missing_ids:
+        logger.info(f"Missing response IDs from LLM output: {missing_ids}")
+    return missing_ids
 
 
 def process_llm_responses(
@@ -355,12 +386,7 @@ def process_llm_responses(
             - If no response_id in LLM output: DataFrame containing only the LLM results
     """
     responses.loc[:, "response_id"] = responses["response_id"].astype(int)
-    unpacked_responses = [
-        response
-        for batch_response in llm_responses
-        for response in batch_response.get("responses", [])
-    ]
-    task_responses = pd.DataFrame(unpacked_responses)
+    task_responses = pd.DataFrame(llm_responses)
     if "response_id" in task_responses.columns:
         task_responses["response_id"] = task_responses["response_id"].astype(int)
         return responses.merge(task_responses, how="inner", on="response_id")
@@ -401,19 +427,18 @@ def build_prompt(
     prompt = prompt_template.format(
         responses=input_batch.to_dict(orient="records"), **kwargs
     )
-    response_ids = input_batch["response_id"].astype(str).to_list()
-
+    response_ids = input_batch["response_id"].astype(int).to_list()
     return BatchPrompt(prompt_string=prompt, response_ids=response_ids)
 
 
 def validate_task_data(
-    task_data: pd.DataFrame | list[dict], task_data_model: Type[BaseModel]
+    task_data: pd.DataFrame | list[dict], task_validation_model: Type[BaseModel] = None
 ) -> tuple[list[dict], list[dict]]:
     """
     Validate each row in task_output against the provided Pydantic model.
 
     Returns:
-        valid: a list of validated recors(dicts).
+        valid: a list of validated records (dicts).
         invalid: a list of records (dicts) that failed validation.
     """
 
@@ -423,11 +448,14 @@ def validate_task_data(
         else task_data
     )
 
-    valid, invalid = [], []
-    for record in records:
-        try:
-            task_data_model(**record)
-            valid.append(record)
-        except ValidationError:
-            invalid.append(record)
-    return valid, invalid
+    if task_validation_model:
+        valid_records, invalid_records = [], []
+        for record in records:
+            try:
+                task_validation_model(**record)
+                valid_records.append(record)
+            except ValidationError as e:
+                invalid_records.append(record)
+                logger.info(f"Failed Validation: {e}")
+        return valid_records, invalid_records
+    return records, []

--- a/src/themefinder/llm_batch_processor.py
+++ b/src/themefinder/llm_batch_processor.py
@@ -159,7 +159,7 @@ def split_overflowing_batch(
     batch: pd.DataFrame, allowed_tokens: int
 ) -> list[pd.DataFrame]:
     """
-    Splits a DataFrame batch into smaller sub-batches such that each sub-batch's total token count 
+    Splits a DataFrame batch into smaller sub-batches such that each sub-batch's total token count
     does not exceed the allowed token limit.
 
     Args:
@@ -208,14 +208,13 @@ def batch_task_input_df(
     partition_key: Optional[str] = None,
 ) -> list[pd.DataFrame]:
     """
-    Partitions and batches a DataFrame according to a token limit and batch size, optionally using 
-    a partition key. Batches that exceed the token limit are further split.
+    Partitions and batches a DataFrame according to a token limit and batch size, optionally using a partition key. Batches that exceed the token limit are further split.
 
     Args:
         df (pd.DataFrame): The input DataFrame to batch.
         allowed_tokens (int): Maximum allowed tokens per batch.
         batch_size (int): Maximum number of rows per batch before token filtering.
-        partition_key (Optional[str], optional): Column name to partition the DataFrame by. 
+        partition_key (Optional[str], optional): Column name to partition the DataFrame by.
             Defaults to None.
 
     Returns:
@@ -418,7 +417,7 @@ def calculate_string_token_length(input_text: str, model: str = None) -> int:
 
     Args:
         input_text (str): The input string to tokenize.
-        model (str, optional): The model name used for tokenization. If not provided, 
+        model (str, optional): The model name used for tokenization. If not provided,
             uses the MODEL_NAME environment variable or defaults to "gpt-4o".
 
     Returns:

--- a/src/themefinder/models.py
+++ b/src/themefinder/models.py
@@ -1,7 +1,20 @@
 from pydantic import BaseModel, Field, model_validator
 
 
-def validate_non_empty_fields(model):
+def validate_non_empty_fields(model: BaseModel) -> BaseModel:
+    """
+    Validate that all string fields in the model are non-empty (after stripping)
+    and that list fields are not empty.
+
+    Args:
+        model (BaseModel): A Pydantic model instance.
+
+    Returns:
+        BaseModel: The same model if validation passes.
+
+    Raises:
+        ValueError: If any string field is empty or any list field is empty.
+    """
     for field_name, value in model.__dict__.items():
         if isinstance(value, str) and not value.strip():
             raise ValueError(f"{field_name} cannot be empty or only whitespace")
@@ -10,14 +23,38 @@ def validate_non_empty_fields(model):
     return model
 
 
-def validate_position(model):
-    allowed_positions = {"agreement", "disagreement", "unclear"}
+def validate_position(model: BaseModel) -> BaseModel:
+    """
+    Validate that the model's 'position' field is one of the allowed values.
+
+    Args:
+        model (BaseModel): A Pydantic model instance with a 'position' attribute.
+
+    Returns:
+        BaseModel: The same model if validation passes.
+
+    Raises:
+        ValueError: If the 'position' field is not one of the allowed values.
+    """
+    allowed_positions = {"AGREEMENT", "DISAGREEMENT", "UNCLEAR"}
     if model.position not in allowed_positions:
         raise ValueError(f"position must be one of {allowed_positions}")
     return model
 
 
-def validate_stances(model):
+def validate_stances(model: BaseModel) -> BaseModel:
+    """
+    Validate that every stance in the model's 'stances' field is allowed.
+
+    Args:
+        model (BaseModel): A Pydantic model instance with a 'stances' attribute.
+
+    Returns:
+        BaseModel: The same model if validation passes.
+
+    Raises:
+        ValueError: If any stance is not among the allowed stances.
+    """
     allowed_stances = {"POSITIVE", "NEGATIVE"}
     for stance in model.stances:
         if stance not in allowed_stances:
@@ -25,26 +62,40 @@ def validate_stances(model):
     return model
 
 
-def validate_mapping_stance_lengths(model):
+def validate_mapping_stance_lengths(model: BaseModel) -> BaseModel:
+    """
+    Validate that the lengths of the model's 'stances' and 'labels' fields match.
+
+    Args:
+        model (BaseModel): A Pydantic model instance with 'stances' and 'labels' attributes.
+
+    Returns:
+        BaseModel: The same model if validation passes.
+
+    Raises:
+        ValueError: If the lengths of 'stances' and 'labels' do not match.
+    """
     if len(model.stances) != len(model.labels):
         raise ValueError("'stances' must have the same length as 'labels'")
     return model
 
 
-def validate_mapping_unique_labels(model):
+def validate_mapping_unique_labels(model: BaseModel) -> BaseModel:
+    """
+    Validate that the model's 'labels' field contains unique values.
+
+    Args:
+        model (BaseModel): A Pydantic model instance with a 'labels' attribute.
+
+    Returns:
+        BaseModel: The same model if validation passes.
+
+    Raises:
+        ValueError: If 'labels' contains duplicate values.
+    """
     if len(model.labels) != len(set(model.labels)):
         raise ValueError("'labels' must be unique")
     return model
-
-
-class SentimentAnalysisInput(BaseModel):
-    response_id: int = Field(gt=0)
-    response: str
-
-    @model_validator(mode="after")
-    def run_validations(self):
-        validate_non_empty_fields(self)
-        return self
 
 
 class SentimentAnalysisOutput(BaseModel):
@@ -52,111 +103,35 @@ class SentimentAnalysisOutput(BaseModel):
     position: str
 
     @model_validator(mode="after")
-    def run_validations(self):
+    def run_validations(self) -> "SentimentAnalysisOutput":
+        """
+        Run all validations for SentimentAnalysisOutput.
+
+        Validates that:
+         - 'position' is one of the allowed values.
+         - No fields are empty or only whitespace (for strings) and no lists are empty.
+        """
         validate_position(self)
-        validate_non_empty_fields(self)
-        return self
-
-
-class ThemeGenerationInput(BaseModel):
-    response_id: int = Field(gt=0)
-    response: str
-    position: str
-
-    @model_validator(mode="after")
-    def run_validations(self):
-        validate_position(self)
-        validate_non_empty_fields(self)
-        return self
-
-
-class ThemeGenerationOutput(BaseModel):
-    topic_label: str
-    topic_description: str
-    position: str
-
-    @model_validator(mode="after")
-    def run_validations(self):
-        validate_position(self)
-        validate_non_empty_fields(self)
-        return self
-
-
-class ThemeCondensationInput(BaseModel):
-    topic_label: str
-    topic_description: str
-    position: str
-
-    @model_validator(mode="after")
-    def run_validations(self):
-        validate_position(self)
-        validate_non_empty_fields(self)
-        return self
-
-
-class ThemeCondensationOutput(BaseModel):
-    topic_label: str
-    topic_description: str
-    source_topic_count: int = Field(ge=0)
-
-    @model_validator(mode="after")
-    def run_validations(self):
-        validate_non_empty_fields(self)
-        return self
-
-
-class ThemeRefinementInput(BaseModel):
-    topic_label: str
-    topic_description: str
-    source_topic_count: int = Field(ge=0)
-
-    @model_validator(mode="after")
-    def run_validations(self):
-        validate_non_empty_fields(self)
-        return self
-
-
-class ThemeRefinementOutput(BaseModel):
-    topic_id: str
-    topic: str
-    source_topic_count: int
-
-    @model_validator(mode="after")
-    def run_validations(self):
-        validate_non_empty_fields(self)
-        return self
-
-
-class ThemeMappingResponseInput(BaseModel):
-    response_id: int = Field(gt=0)
-    response: str
-    position: str
-
-    @model_validator(mode="after")
-    def run_validations(self):
-        validate_position(self)
-        validate_non_empty_fields(self)
-        return self
-
-
-class ThemeMappingThemeInput(BaseModel):
-    topic_id: str
-    topic: str
-
-    @model_validator(mode="after")
-    def run_validations(self):
         validate_non_empty_fields(self)
         return self
 
 
 class ThemeMappingOutput(BaseModel):
-    response_id: int = Field(ge=0)
+    response_id: int = Field(gt=0)
     labels: list[str]
     reasons: list[str]
     stances: list[str]
 
     @model_validator(mode="after")
-    def run_validations(self):
+    def run_validations(self) -> "ThemeMappingOutput":
+        """
+        Run all validations for ThemeMappingOutput.
+
+        Validates that:
+         - 'stances' are only 'POSITIVE' or 'NEGATIVE'.
+         - The 'stances' and 'labels' have matching lengths.
+         - 'labels' are unique.
+        """
         validate_stances(self)
         validate_mapping_stance_lengths(self)
         validate_mapping_unique_labels(self)

--- a/src/themefinder/models.py
+++ b/src/themefinder/models.py
@@ -25,9 +25,7 @@ def validate_stances(model):
     return model
 
 
-def validate_mapping_reason_and_stance_lengths(model):
-    if len(model.reasons) != len(model.labels):
-        raise ValueError("'reasons' must have the same length as 'labels'")
+def validate_mapping_stance_lengths(model):
     if len(model.stances) != len(model.labels):
         raise ValueError("'stances' must have the same length as 'labels'")
     return model
@@ -51,7 +49,6 @@ class SentimentAnalysisInput(BaseModel):
 
 class SentimentAnalysisOutput(BaseModel):
     response_id: int = Field(gt=0)
-    response: str
     position: str
 
     @model_validator(mode="after")
@@ -154,17 +151,13 @@ class ThemeMappingThemeInput(BaseModel):
 
 class ThemeMappingOutput(BaseModel):
     response_id: int = Field(ge=0)
-    response: str
-    position: str
     labels: list[str]
     reasons: list[str]
     stances: list[str]
 
     @model_validator(mode="after")
     def run_validations(self):
-        validate_position(self)
         validate_stances(self)
-        validate_mapping_reason_and_stance_lengths(self)
+        validate_mapping_stance_lengths(self)
         validate_mapping_unique_labels(self)
-        validate_non_empty_fields(self)
         return self

--- a/src/themefinder/prompts/sentiment_analysis.txt
+++ b/src/themefinder/prompts/sentiment_analysis.txt
@@ -3,8 +3,8 @@
 You will receive a list of RESPONSES, each containing a response_id and a response.
 Your job is to analyze each response to the QUESTION below and decide:
 
-POSITION - is the response agreeing or disagreeing or is it unclear about the change being proposed in the question.
-Choose one from [agreement, disagreement, unclear]
+POSITION - is the response AGREEING or DISAGREEING or is it UNCLEAR about the change being proposed in the question.
+Choose one from [AGREEMENT, DISAGREEMENT, UNCLEAR]
 
 The final output should be in the following JSON format:
 
@@ -33,14 +33,14 @@ Question: \n What are your thoughts on the proposed government changes to the po
 Response: \n as a parent I have no idea why you would make this change. I guess you were thinking about increasing productivity but any productivity gains would be totally offset by the decrease in family time. \n
 
 Output:
-POSITION: disagreement
+POSITION: DISAGREEMENT
 
 Example 2:
 Question: \n What are your thoughts on the proposed government changes to the policy about reducing school holidays?
 Response: \n I think this is a great idea, our children will learn more if they are in school more \n
 
 Output:
-POSITION: agreement
+POSITION: AGREEMENT
 
 Example 3:
 Question: \n What are your thoughts on the proposed government changes to the policy about reducing school holidays?
@@ -48,7 +48,7 @@ Response: \n it will be good for our children to be around their friends more bu
 less time with their children \n
 
 Output:
-POSITION: unclear
+POSITION: UNCLEAR
 
 
 QUESTION: \n {question}

--- a/src/themefinder/prompts/theme_mapping.txt
+++ b/src/themefinder/prompts/theme_mapping.txt
@@ -17,7 +17,7 @@ Your task is to analyze each response and decide which topics are present. Guide
     - There is no limit on how many topics can be assigned to a response.
     - For each assignment provide a single rationale for why you have chosen the label.
     - For each topic identified in a response, indicate whether the response expresses a positive or negative stance toward that topic (options: 'POSITIVE' or 'NEGATIVE')
-    - If a response contains both positive and negative statements about a topic within the same response, choose the stance that receives more emphasis or appears more central to the argument
+    - You MUST use either 'POSTIVE' or 'NEGATIVE'
     - The order of reasons and stances must align with the order of labels (e.g., stance_a applies to topic_a)
 
 You MUST include every response ID in the output.
@@ -30,13 +30,13 @@ The final output should be in the following JSON format:
 {{
   "responses": [
     {{
-      "response_id": "response_id_1",
+      "response_id": response_id_1,
       "reasons": ["reason_a", "reason_b"],
       "labels": ["topic_a", "topic_b"],
       "stances": ["stance_a", "stance_b"],
     }},
     {{
-      "response_id": "response_id_2",
+      "response_id": response_id_2,
       "reasons": ["reason_c"],
       "labels": ["topic_c"],
       "stances": ["stance_c"],

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -61,8 +61,8 @@ async def test_sentiment_analysis(mock_llm, sample_df):
         content=json.dumps(
             {
                 "responses": [
-                    {"response_id": 1, "position": "agreement"},
-                    {"response_id": 2, "position": "disagreement"},
+                    {"response_id": 1, "position": "AGREEMENT"},
+                    {"response_id": 2, "position": "DISAGREEMENT"},
                 ]
             }
         )
@@ -70,8 +70,6 @@ async def test_sentiment_analysis(mock_llm, sample_df):
     result, _ = await sentiment_analysis(
         sample_df, mock_llm, question="test question", batch_size=2
     )
-    print("result", result)
-    print("failed", _)
     assert isinstance(result, pd.DataFrame)
     assert "position" in result.columns
     assert mock_llm.ainvoke.call_count == 1
@@ -220,7 +218,6 @@ async def test_theme_mapping(mock_llm, sample_sentiment_df):
         refined_themes_df=refined_df,
         batch_size=2,
     )
-    print("TM result", result)
     assert isinstance(result, pd.DataFrame)
     assert "response_id" in result.columns
     assert "reasons" in result.columns
@@ -233,7 +230,9 @@ async def test_theme_mapping(mock_llm, sample_sentiment_df):
 async def test_find_themes(monkeypatch):
     # Dummy async functions returning simple DataFrames
     async def dummy_sentiment_analysis(responses_df, llm, question, system_prompt):
-        return pd.DataFrame({"sentiment": ["positive"]}), pd.DataFrame()
+        return pd.DataFrame(
+            {"response_id": 1, "response": "dummy", "sentiment": ["POSITIVE"]}
+        ), pd.DataFrame()
 
     async def dummy_theme_generation(sentiment_df, llm, question, system_prompt):
         return pd.DataFrame({"theme": ["theme1"]}), pd.DataFrame()
@@ -288,8 +287,6 @@ async def test_find_themes(monkeypatch):
         "question",
         "sentiment",
         "themes",
-        "condensed_themes",
-        "refined_themes",
         "mapping",
         "unprocessables",
     }
@@ -299,7 +296,7 @@ async def test_find_themes(monkeypatch):
     assert result["question"] == question
 
     # Verify that each stage returns a DataFrame with content.
-    for key in ["sentiment", "themes", "condensed_themes", "refined_themes", "mapping"]:
+    for key in ["sentiment", "themes", "mapping"]:
         df = result[key]
         assert isinstance(df, pd.DataFrame)
         assert not df.empty

--- a/tests/test_llm_batch_processor.py
+++ b/tests/test_llm_batch_processor.py
@@ -1,14 +1,18 @@
 from unittest.mock import MagicMock
 
+import httpx
+import openai
 import pandas as pd
 import pytest
 import tiktoken
 
 from themefinder import sentiment_analysis
 from themefinder.llm_batch_processor import (
+    BatchPrompt,
     batch_task_input_df,
     build_prompt,
     calculate_string_token_length,
+    call_llm,
     generate_prompts,
     process_llm_responses,
     split_overflowing_batch,
@@ -24,7 +28,7 @@ async def test_process_llm_responses_with_clashing_types():
     responses = pd.DataFrame({"response_id": [1], "text": ["response1"]})
     processed = process_llm_responses(
         # llm gives us a str response_id but the original response_id is an int
-        [{"responses": [{"response_id": "1", "llm_contribution": "banana"}]}],
+        [{"response_id": 1, "llm_contribution": "banana"}],
         responses,
     )
     assert list(processed["response_id"]) == [1]
@@ -45,7 +49,7 @@ async def test_retries(mock_llm, sample_df):
             content='{"responses": [{"response_id": 1, "position": "agreement", "text": "response1"}, {"response_id": 2, "position": "disagreement", "text": "response2"}]}'
         ),
     ]
-    result = await sentiment_analysis(sample_df, mock_llm, question="doesn't matter")
+    result, _ = await sentiment_analysis(sample_df, mock_llm, question="doesn't matter")
     # we got something back
     assert isinstance(result, pd.DataFrame)
     # we hit the llm twice
@@ -83,7 +87,6 @@ def test_calls_encoding_for_model(monkeypatch):
     assert token_length == 3
 
 
-# Define a dummy prompt template with a template attribute and a predictable format() method.
 class DummyPromptTemplate:
     def __init__(self, template):
         self.template = template
@@ -107,7 +110,7 @@ def test_build_prompt():
         f"Prompt with {len(df.to_dict(orient='records'))} responses. {extra_info}"
     )
     assert result.prompt_string == expected_prompt
-    assert result.response_ids == ["1", "2"]
+    assert result.response_ids == [1, 2]
 
 
 def test_build_prompt_with_mock_template():
@@ -124,7 +127,7 @@ def test_build_prompt_with_mock_template():
     )
 
     assert result.prompt_string == "formatted prompt"
-    assert result.response_ids == ["101", "202"]
+    assert result.response_ids == [101, 202]
 
 
 def dummy_token_length_low(input_text: str, model="gpt-4o"):
@@ -464,11 +467,11 @@ def test_generate_prompts(monkeypatch, dummy_input_data):
     # "Formatted: 2 responses. foo"
     assert prompts[0].prompt_string == "Prompt with 2 responses. foo"
     # And response IDs should be converted to strings.
-    assert prompts[0].response_ids == ["1", "2"]
+    assert prompts[0].response_ids == [1, 2]
 
     # For batch2, which has 1 row:
     assert prompts[1].prompt_string == "Prompt with 1 responses. foo"
-    assert prompts[1].response_ids == ["3"]
+    assert prompts[1].response_ids == [3]
 
 
 def test_generate_prompts_with_partition(monkeypatch):
@@ -525,10 +528,35 @@ def test_generate_prompts_with_partition(monkeypatch):
 
     # Since groupby order is not guaranteed, collect the response IDs from both prompts.
     response_ids = {tuple(prompt.response_ids) for prompt in prompts}
-    expected = {("1", "2"), ("3", "4")}
+    expected = {(1, 2), (3, 4)}
     assert response_ids == expected
 
     # Also verify that the prompt string includes the correct number of responses.
     for prompt in prompts:
         if len(prompt.response_ids) == 2:
             assert prompt.prompt_string == "Prompt with 2 responses. bar"
+
+
+@pytest.mark.asyncio
+async def test_call_llm_bad_request(monkeypatch, mock_llm):
+    batch_prompts = [BatchPrompt(prompt_string="dummy prompt", response_ids=[1, 2])]
+
+    class DummyBadRequestError(openai.BadRequestError):
+        def __init__(self, *args, **kwargs):
+            dummy_request = httpx.Request("GET", "http://dummy.url")
+            dummy_response = httpx.Response(
+                status_code=400,
+                content=b'{"error": "dummy"}',
+                headers={"Content-Type": "application/json"},
+                request=dummy_request,
+            )
+            super().__init__(
+                "dummy message", response=dummy_response, body="dummy body"
+            )
+
+    mock_llm.ainvoke.side_effect = DummyBadRequestError()
+    results, failed_ids = await call_llm(batch_prompts, mock_llm)
+
+    # Verify that each response id in the result contains the expected failure details.
+    for response_id in batch_prompts[0].response_ids:
+        assert response_id in failed_ids

--- a/tests/test_llm_batch_processor.py
+++ b/tests/test_llm_batch_processor.py
@@ -46,7 +46,7 @@ async def test_retries(mock_llm, sample_df):
     mock_llm.ainvoke.side_effect = [
         exception,
         MagicMock(
-            content='{"responses": [{"response_id": 1, "position": "agreement", "text": "response1"}, {"response_id": 2, "position": "disagreement", "text": "response2"}]}'
+            content='{"responses": [{"response_id": 1, "position": "AGREEMENT", "text": "response1"}, {"response_id": 2, "position": "DISAGREEMENT", "text": "response2"}]}'
         ),
     ]
     result, _ = await sentiment_analysis(sample_df, mock_llm, question="doesn't matter")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,17 +2,8 @@ import pytest
 from pydantic import BaseModel, ValidationError
 
 from themefinder.models import (
-    SentimentAnalysisInput,
     SentimentAnalysisOutput,
-    ThemeCondensationInput,
-    ThemeCondensationOutput,
-    ThemeGenerationInput,
-    ThemeGenerationOutput,
     ThemeMappingOutput,
-    ThemeMappingResponseInput,
-    ThemeMappingThemeInput,
-    ThemeRefinementInput,
-    ThemeRefinementOutput,
     validate_mapping_stance_lengths,
     validate_non_empty_fields,
     validate_position,
@@ -50,7 +41,7 @@ def test_validate_non_empty_fields_invalid():
 
 # === Tests for validate_position ===
 def test_validate_position_valid():
-    model = MockModel(response_id=1, response="Valid response", position="agreement")
+    model = MockModel(response_id=1, response="Valid response", position="AGREEMENT")
     validate_position(model)  # Should not raise error
 
 
@@ -135,27 +126,12 @@ def test_validate_mapping_stance_lengths_invalid():
         validate_mapping_stance_lengths(model)
 
 
-# === SentimentAnalysisInput ===
-def test_sentiment_analysis_input_valid():
-    model = SentimentAnalysisInput(response_id=1, response="This is a test response.")
-    assert model.response_id == 1
-
-
-def test_sentiment_analysis_input_invalid():
-    raises_validation_error(
-        SentimentAnalysisInput, {"response_id": 0, "response": "Valid text"}
-    )
-    raises_validation_error(
-        SentimentAnalysisInput, {"response_id": 1, "response": "  "}
-    )
-
-
 # === SentimentAnalysisOutput ===
 def test_sentiment_analysis_output_valid():
     model = SentimentAnalysisOutput(
-        response_id=1, response="Test response", position="agreement"
+        response_id=1, response="Test response", position="AGREEMENT"
     )
-    assert model.position == "agreement"
+    assert model.position == "AGREEMENT"
 
 
 def test_sentiment_analysis_output_invalid_position():
@@ -163,123 +139,6 @@ def test_sentiment_analysis_output_invalid_position():
         SentimentAnalysisOutput,
         {"response_id": 1, "position": "invalid"},
     )
-
-
-# === ThemeGenerationInput ===
-def test_theme_generation_input_valid():
-    model = ThemeGenerationInput(
-        response_id=1, response="Test response", position="disagreement"
-    )
-    assert model.position == "disagreement"
-
-
-def test_theme_generation_input_invalid():
-    raises_validation_error(
-        ThemeGenerationInput,
-        {"response_id": 1, "response": "Valid", "position": "wrong_value"},
-    )
-
-
-# === ThemeGenerationOutput ===
-def test_theme_generation_output_valid():
-    model = ThemeGenerationOutput(
-        topic_label="Label", topic_description="Desc", position="unclear"
-    )
-    assert model.topic_label == "Label"
-
-
-def test_theme_generation_output_invalid():
-    raises_validation_error(
-        ThemeGenerationOutput,
-        {"topic_label": "", "topic_description": "Valid", "position": "agreement"},
-    )
-
-
-# === ThemeCondensationInput ===
-def test_theme_condensation_input_valid():
-    model = ThemeCondensationInput(
-        topic_label="Topic", topic_description="Description", position="agreement"
-    )
-    assert model.position == "agreement"
-
-
-def test_theme_condensation_input_invalid():
-    raises_validation_error(
-        ThemeCondensationInput,
-        {"topic_label": "Valid", "topic_description": "", "position": "agreement"},
-    )
-    raises_validation_error(
-        ThemeCondensationInput,
-        {"topic_label": "Valid", "topic_description": "Valid", "position": "wrong"},
-    )
-
-
-# === ThemeCondensationOutput ===
-def test_theme_condensation_output_valid():
-    model = ThemeCondensationOutput(
-        topic_label="Topic", topic_description="Desc", source_topic_count=5
-    )
-    assert model.source_topic_count == 5
-
-
-def test_theme_condensation_output_invalid():
-    raises_validation_error(
-        ThemeCondensationOutput,
-        {"topic_label": "Label", "topic_description": "Desc", "source_topic_count": -1},
-    )
-
-
-# === ThemeRefinementInput ===
-def test_theme_refinement_input_valid():
-    model = ThemeRefinementInput(
-        topic_label="Topic", topic_description="Desc", source_topic_count=3
-    )
-    assert model.source_topic_count == 3
-
-
-def test_theme_refinement_input_invalid():
-    raises_validation_error(
-        ThemeRefinementInput,
-        {"topic_label": "", "topic_description": "Valid", "source_topic_count": 2},
-    )
-
-
-# === ThemeRefinementOutput ===
-def test_theme_refinement_output_valid():
-    model = ThemeRefinementOutput(topic_id="123", topic="Test", source_topic_count=2)
-    assert model.topic_id == "123"
-
-
-def test_theme_refinement_output_invalid():
-    raises_validation_error(
-        ThemeRefinementOutput,
-        {"topic_id": "", "topic": "Valid", "source_topic_count": 2},
-    )
-
-
-# === ThemeMappingResponseInput ===
-def test_theme_mapping_response_input_valid():
-    model = ThemeMappingResponseInput(
-        response_id=1, response="Valid", position="disagreement"
-    )
-    assert model.response_id == 1
-
-
-def test_theme_mapping_response_input_invalid():
-    raises_validation_error(
-        ThemeMappingResponseInput,
-        {"response_id": 1, "response": "Valid", "position": "incorrect"},
-    )
-
-
-# === ThemeMappingThemeInput ===
-def test_theme_mapping_theme_input_valid():
-    model = ThemeMappingThemeInput(topic_id="123", topic="Valid")
-    assert model.topic_id == "123"
-
-
-def test_theme_mapping_theme_input_invalid():
-    raises_validation_error(ThemeMappingThemeInput, {"topic_id": "", "topic": "Valid"})
 
 
 # === ThemeMappingOutput ===
@@ -292,7 +151,7 @@ def test_theme_mapping_output_valid():
         reasons=["Reason1", "Reason2"],
         stances=["POSITIVE", "NEGATIVE"],
     )
-    assert len(model.labels) == len(model.reasons) == len(model.stances)
+    assert len(model.labels) == len(model.stances)
 
 
 def test_theme_mapping_output_invalid_stance():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -13,7 +13,7 @@ from themefinder.models import (
     ThemeMappingThemeInput,
     ThemeRefinementInput,
     ThemeRefinementOutput,
-    validate_mapping_reason_and_stance_lengths,
+    validate_mapping_stance_lengths,
     validate_non_empty_fields,
     validate_position,
     validate_stances,
@@ -109,8 +109,8 @@ def test_validate_mapping_unique_labels_invalid():
         validate_mapping_unique_labels(model)
 
 
-# === Tests for validate_mapping_reason_and_stance_lengths ===
-def test_validate_mapping_reason_and_stance_lengths_valid():
+# === Tests for validate_mapping_stance_lengths ===
+def test_validate_mapping_stance_lengths_valid():
     model = MockModel(
         response_id=1,
         response="Valid response",
@@ -118,22 +118,10 @@ def test_validate_mapping_reason_and_stance_lengths_valid():
         reasons=["Reason1", "Reason2"],
         stances=["POSITIVE", "NEGATIVE"],
     )
-    validate_mapping_reason_and_stance_lengths(model)  # Should not raise error
+    validate_mapping_stance_lengths(model)  # Should not raise error
 
 
-def test_validate_mapping_reason_and_stance_lengths_invalid():
-    model = MockModel(
-        response_id=1,
-        response="Valid response",
-        labels=["Label1"],
-        reasons=["Reason1", "Reason2"],  # Mismatch in length
-        stances=["POSITIVE"],
-    )
-    with pytest.raises(
-        ValueError, match="'reasons' must have the same length as 'labels'"
-    ):
-        validate_mapping_reason_and_stance_lengths(model)
-
+def test_validate_mapping_stance_lengths_invalid():
     model = MockModel(
         response_id=1,
         response="Valid response",
@@ -144,7 +132,7 @@ def test_validate_mapping_reason_and_stance_lengths_invalid():
     with pytest.raises(
         ValueError, match="'stances' must have the same length as 'labels'"
     ):
-        validate_mapping_reason_and_stance_lengths(model)
+        validate_mapping_stance_lengths(model)
 
 
 # === SentimentAnalysisInput ===
@@ -170,14 +158,10 @@ def test_sentiment_analysis_output_valid():
     assert model.position == "agreement"
 
 
-def test_sentiment_analysis_output_invalid():
+def test_sentiment_analysis_output_invalid_position():
     raises_validation_error(
         SentimentAnalysisOutput,
-        {"response_id": 1, "response": "Text", "position": "invalid"},
-    )
-    raises_validation_error(
-        SentimentAnalysisOutput,
-        {"response_id": 1, "response": "", "position": "agreement"},
+        {"response_id": 1, "position": "invalid"},
     )
 
 
@@ -311,18 +295,7 @@ def test_theme_mapping_output_valid():
     assert len(model.labels) == len(model.reasons) == len(model.stances)
 
 
-def test_theme_mapping_output_invalid():
-    raises_validation_error(
-        ThemeMappingOutput,
-        {
-            "response_id": 1,
-            "response": "Valid",
-            "position": "wrong_value",
-            "labels": ["Label1"],
-            "reasons": ["Reason1", "Reason2"],  # Different length
-            "stances": ["POSITIVE"],
-        },
-    )
+def test_theme_mapping_output_invalid_stance():
     raises_validation_error(
         ThemeMappingOutput,
         {


### PR DESCRIPTION
Implementation of error handling and validation of the pipeline.

- JSON errors from prematurely truncated LLM responses
- Content Filter errors from OpenAI
- Missing response IDs
- Pydantic model validation failures

Initial batch failures are rerun in a batch size of 1 and rerun batch failures are considered unprocessable and excluded from further processing.

Something to consider but isnt currently implemented - should task input be validated?