### PR TITLE
Update: pipeline to expose concurrency as argument.

### DIFF
--- a/src/themefinder/llm_batch_processor.py
+++ b/src/themefinder/llm_batch_processor.py
@@ -37,6 +37,7 @@ async def batch_and_run(
     partition_key: str | None = None,
     validation_check: bool = False,
     task_validation_model: Optional[Type[BaseModel]] = None,
+    concurrency: int = 10,
     **kwargs: Any,
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
     """Process a DataFrame of responses in batches using an LLM.
@@ -56,6 +57,8 @@ async def batch_and_run(
             failed rows are retried individually.
             If False, no integrity checking or retrying occurs. Defaults to False.
         task_validation_model (Optional[Type[BaseModel]]): the pydanctic model to validate each row against
+        concurrency (int, optional): Maximum number of simultaneous LLM calls allowed.
+            Defaults to 10.
         **kwargs (Any): Additional keyword arguments to pass to the prompt template.
 
     Returns:
@@ -82,6 +85,7 @@ async def batch_and_run(
         llm=llm,
         validation_check=validation_check,
         task_validation_model=task_validation_model,
+        concurrency=concurrency,
     )
     processed_results = process_llm_responses(processed_rows, input_df)
 
@@ -95,6 +99,7 @@ async def batch_and_run(
             llm=llm,
             validation_check=validation_check,
             task_validation_model=task_validation_model,
+            concurrency=concurrency,
         )
         retry_processed_results = process_llm_responses(retry_results, retry_df)
         unprocessable_df = retry_df.loc[retry_df["response_id"].isin(unprocessable_ids)]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -229,29 +229,37 @@ async def test_theme_mapping(mock_llm, sample_sentiment_df):
 @pytest.mark.asyncio
 async def test_find_themes(monkeypatch):
     # Dummy async functions returning simple DataFrames
-    async def dummy_sentiment_analysis(responses_df, llm, question, system_prompt):
+    async def dummy_sentiment_analysis(
+        responses_df, llm, question, system_prompt, concurrency
+    ):
         return pd.DataFrame(
             {"response_id": 1, "response": "dummy", "sentiment": ["POSITIVE"]}
         ), pd.DataFrame()
 
-    async def dummy_theme_generation(sentiment_df, llm, question, system_prompt):
+    async def dummy_theme_generation(
+        sentiment_df, llm, question, system_prompt, concurrency
+    ):
         return pd.DataFrame({"theme": ["theme1"]}), pd.DataFrame()
 
-    async def dummy_theme_condensation(theme_df, llm, question, system_prompt):
+    async def dummy_theme_condensation(
+        theme_df, llm, question, system_prompt, concurrency
+    ):
         return pd.DataFrame({"condensed_theme": ["condensed_theme1"]}), pd.DataFrame()
 
-    async def dummy_theme_refinement(condensed_theme_df, llm, question, system_prompt):
+    async def dummy_theme_refinement(
+        condensed_theme_df, llm, question, system_prompt, concurrency
+    ):
         return pd.DataFrame({"refined_theme": ["refined_theme1"]}), pd.DataFrame()
 
     async def dummy_theme_target_alignment(
-        refined_theme_df, llm, question, target_n_themes, system_prompt
+        refined_theme_df, llm, question, target_n_themes, system_prompt, concurrency
     ):
         return pd.DataFrame(
             {"refined_theme": [f"aligned_theme_for_{target_n_themes}"]}
         ), pd.DataFrame()
 
     async def dummy_theme_mapping(
-        sentiment_df, llm, question, refined_themes_df, system_prompt
+        sentiment_df, llm, question, refined_themes_df, system_prompt, concurrency
     ):
         return pd.DataFrame({"mapping": ["mapped_theme1"]}), pd.DataFrame()
 


### PR DESCRIPTION
We are hitting rate limit errors so we may want to reduce concurrency going forward. This has also been specifically requested in this issue https://github.com/i-dot-ai/themefinder/issues/39.

This exposes concurrency as an argument for each of the core tasks and for `find_themes`.