### PR TITLE
Feature/trusted publisher

### DIFF
--- a/.github/workflows/deploy-pypi.yml
+++ b/.github/workflows/deploy-pypi.yml
@@ -42,12 +42,10 @@ jobs:
         run: |
           echo "PACKAGE_VERSION=$(poetry run python -c "import toml; print(toml.load('pyproject.toml')['tool']['poetry']['version'])")" >> $GITHUB_ENV
 
-
       - name: Extract tag name
         id: extract_tag
         run: |
           echo "TAG_NAME=${GITHUB_REF_NAME#'v'}" >> $GITHUB_ENV
-
         
       - name: Compare tag with version
         run: |
@@ -58,10 +56,6 @@ jobs:
             echo "Tag does not match the pyproject.toml version."
             exit 1
           fi
-
-      - name: Install dependencies
-        run: |
-          poetry install --sync --no-interaction
 
       - name: Package project
         run: poetry build

--- a/.github/workflows/deploy-pypi.yml
+++ b/.github/workflows/deploy-pypi.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -56,10 +59,13 @@ jobs:
             exit 1
           fi
 
-      - name: Set Poetry config
+      - name: Install dependencies
         run: |
-          poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
+          poetry install --sync --no-interaction
 
-      - name: Publish package
-        run: poetry publish --build
+      - name: Package project
+        run: poetry build
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
 

--- a/.github/workflows/deploy-test-pypi.yml
+++ b/.github/workflows/deploy-test-pypi.yml
@@ -9,7 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     environment: test-pypi
     permissions:
-      # IMPORTANT: this permission is mandatory for Trusted Publishing
       id-token: write
 
     steps:

--- a/.github/workflows/deploy-test-pypi.yml
+++ b/.github/workflows/deploy-test-pypi.yml
@@ -5,8 +5,12 @@ on:
     types: [prereleased]
 
 jobs:
-  deploy-test:
+  deploy-test-pypi:
     runs-on: ubuntu-latest
+    environment: test-pypi
+    permissions:
+      # IMPORTANT: this permission is mandatory for Trusted Publishing
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -46,11 +50,14 @@ jobs:
             exit 1
           fi
 
-      - name: Set Poetry config for testpypi
+      - name: Install dependencies
         run: |
-          poetry config repositories.testpypi https://test.pypi.org/legacy/
-          poetry config pypi-token.testpypi ${{ secrets.TEST_PYPI_API_TOKEN }}
-            
-      - name: Publish package for test pypi
-        run: poetry publish --build -r testpypi
+          poetry install --sync --no-interaction
 
+      - name: Package project
+        run: poetry build
+
+      - name: Publish package distributions to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "themefinder"
-version = "0.0.5"
+version = "0.6.3"
 description = "A topic modelling Python package designed for analysing one-to-many question-answer data eg free-text survey responses."
 authors = ["i.AI <packages@cabinetoffice.gov.uk>"]
 packages = [{include = "themefinder", from = "src"}]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "themefinder"
-version = "0.0.4"
+version = "0.0.5"
 description = "A topic modelling Python package designed for analysing one-to-many question-answer data eg free-text survey responses."
 authors = ["i.AI <packages@cabinetoffice.gov.uk>"]
 packages = [{include = "themefinder", from = "src"}]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "themefinder"
-version = "0.6.3"
+version = "0.0.4"
 description = "A topic modelling Python package designed for analysing one-to-many question-answer data eg free-text survey responses."
 authors = ["i.AI <packages@cabinetoffice.gov.uk>"]
 packages = [{include = "themefinder", from = "src"}]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "themefinder"
-version = "0.0.3"
+version = "0.6.3"
 description = "A topic modelling Python package designed for analysing one-to-many question-answer data eg free-text survey responses."
 authors = ["i.AI <packages@cabinetoffice.gov.uk>"]
 packages = [{include = "themefinder", from = "src"}]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "themefinder"
-version = "0.0.2"
+version = "0.0.3"
 description = "A topic modelling Python package designed for analysing one-to-many question-answer data eg free-text survey responses."
 authors = ["i.AI <packages@cabinetoffice.gov.uk>"]
 packages = [{include = "themefinder", from = "src"}]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "themefinder"
-version = "0.6.3"
+version = "0.0.2"
 description = "A topic modelling Python package designed for analysing one-to-many question-answer data eg free-text survey responses."
 authors = ["i.AI <packages@cabinetoffice.gov.uk>"]
 packages = [{include = "themefinder", from = "src"}]


### PR DESCRIPTION
Use "Trusted Publishing" to publish package to Test PyPi and PyPi. Background: https://docs.pypi.org/trusted-publishers/.

This should be more secure than using API keys generated by each user - and more resilient as people leave.

Have tested by creating a fake release [0.0.5](https://github.com/i-dot-ai/themefinder/releases/tag/v0.0.5) which has published to [Test PyPi](https://test.pypi.org/project/themefinder/0.0.5/) on pre-release and [PyPi](https://pypi.org/project/themefinder/0.0.5/) on release. Existing API keys for TestPyPi and PyPi have been deleted from the repo, so this has tested that we're using trusted publishing.

Current release process is here: https://i-dot-ai.github.io/themefinder/internal_contributors/#releasing-to-pypi.

