### PR TITLE
Change prompt to prevent no labels being assigned

### DIFF
--- a/src/themefinder/prompts/theme_mapping.txt
+++ b/src/themefinder/prompts/theme_mapping.txt
@@ -18,7 +18,7 @@ Your task is to analyze each response and decide which topics are present. Guide
     - There is no limit on how many topics can be assigned to a response.
 
 You MUST include every response ID in the output.
-If none of the themes are relevant to the response then use the fallback themes provided at the end of the list such as None of the Above or Other
+If none of the themes are relevant to the response then use the most appropriate of the fallback themes provided at the end of the list: either No Reason Given or Other
 You MUST return an entry with the correct response ID for each input object.
 You must only return the alphabetic topic_ids in the labels section.
 


### PR DESCRIPTION
Structured output validation does not seem to work to prevent empty lists being returned, temporary prompt change to prevent this until a better fix