### PR TITLE
fix: Missing questions in consultation setup

### DIFF
--- a/setup_consultation.py
+++ b/setup_consultation.py
@@ -66,7 +66,7 @@ def save_demographic_data(
     responses_df: pd.DataFrame, question_understanding_path: str, output_dir: str
 ) -> None:
     demographic_info = pd.read_excel(
-        question_understanding_path, sheet_name="Demographic", skiprows=3
+        question_understanding_path, sheet_name="Demographic", skiprows=3, header=None
     )
     if demographic_info.empty:
         print("  No demographic data found, skipping.")
@@ -131,7 +131,10 @@ def save_open_questions(
     responses_df: pd.DataFrame, question_understanding_path: str, output_dir: str
 ) -> None:
     question_info = pd.read_excel(
-        question_understanding_path, sheet_name="Open questions", skiprows=3
+        question_understanding_path,
+        sheet_name="Open questions",
+        skiprows=3,
+        header=None,
     )
     if question_info.empty:
         print("  No open questions found, skipping.")
@@ -241,7 +244,10 @@ def save_hybrid_questions(
     responses_df: pd.DataFrame, question_understanding_path: str, output_dir: str
 ) -> None:
     question_info = pd.read_excel(
-        question_understanding_path, sheet_name="Hybrid questions", skiprows=3
+        question_understanding_path,
+        sheet_name="Hybrid questions",
+        skiprows=3,
+        header=None,
     )
     if question_info.empty:
         print("  No hybrid questions found, skipping.")
@@ -326,7 +332,10 @@ def save_closed_questions(
     responses_df: pd.DataFrame, question_understanding_path: str, output_dir: str
 ) -> None:
     question_info = pd.read_excel(
-        question_understanding_path, sheet_name="Multiple Choice", skiprows=3
+        question_understanding_path,
+        sheet_name="Multiple Choice",
+        skiprows=3,
+        header=None,
     )
     if question_info.empty:
         print("  No closed questions found, skipping.")


### PR DESCRIPTION
We were missing the first question for each type (demographic, closed, open, hybrid) because we both skipped the first three rows and treat the first row as a header.