### PR TITLE
fix: fail eval CI job when no results are collected

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -87,6 +87,7 @@ jobs:
           DATASET: ${{ github.event.inputs.dataset || 'gambling_XS' }}
           EVAL_TYPE: ${{ github.event.inputs.eval_type || 'generation' }}
         run: |
+          set -o pipefail
           cd evals
 
           if [ "$EVAL_TYPE" = "all" ]; then

--- a/evals/benchmark.py
+++ b/evals/benchmark.py
@@ -221,7 +221,7 @@ AZURE_MODELS = [
     ModelConfig(name="gpt-5-nano", deployment="gpt-5-nano", reasoning_effort="low"),
     ModelConfig(name="gpt-5-mini", deployment="gpt-5-mini", reasoning_effort="low"),
 ]
- 
+
 # Vertex AI models (Gemini and Claude)
 # Requires: uv pip install -e ".[vertex]" and GOOGLE_CLOUD_PROJECT env var
 VERTEX_MODELS = [

--- a/evals/benchmark.py
+++ b/evals/benchmark.py
@@ -31,6 +31,7 @@ import asyncio
 import json
 import logging
 import os
+import sys
 import time
 from contextvars import ContextVar
 from dataclasses import dataclass, field
@@ -861,7 +862,7 @@ def query_langfuse_costs(benchmark_id: str) -> pd.DataFrame:
         # Fetch traces with benchmark tag
         traces = client.api.trace.list(
             tags=[f"benchmark:{benchmark_id}"],
-            limit=1000,
+            limit=100,
         )
 
         if not traces.data:
@@ -1074,6 +1075,13 @@ Examples:
 
     # Print results
     runner.print_results_table()
+
+    if not runner.results:
+        console.print(
+            "[bold red]No results collected — all evals failed "
+            "(check for authentication errors above)[/bold red]"
+        )
+        sys.exit(1)
 
     # Query and print costs
     cost_df = query_langfuse_costs(runner.benchmark_id)

--- a/evals/benchmark.py
+++ b/evals/benchmark.py
@@ -221,7 +221,7 @@ AZURE_MODELS = [
     ModelConfig(name="gpt-5-nano", deployment="gpt-5-nano", reasoning_effort="low"),
     ModelConfig(name="gpt-5-mini", deployment="gpt-5-mini", reasoning_effort="low"),
 ]
-
+ 
 # Vertex AI models (Gemini and Claude)
 # Requires: uv pip install -e ".[vertex]" and GOOGLE_CLOUD_PROJECT env var
 VERTEX_MODELS = [


### PR DESCRIPTION
LLM auth errors were causing all eval calls to fail silently — benchmark.py exited 0 with empty results, and the | tee pipe in CI swallowed the exit code anyway. The job reported success.

- Exit 1 in benchmark.py when runner.results is empty after all evals complete
- Add set -o pipefail to the eval workflow step so benchmark.py's exit code propagates through the tee pipe and fails the job
- Cap Langfuse trace list limit at 100 (API rejects values above 100)