### PR TITLE
fix: Strip whitespace from response text in setup_consultation

### DIFF
--- a/setup_consultation.py
+++ b/setup_consultation.py
@@ -325,12 +325,22 @@ def validate_data(
         issues.append(f"Q.U. references missing columns: {', '.join(missing_cols)}")
 
     # ── Column data type checks ─────────────────────────────────────────
-    # Multichoice columns should have few unique values and few distinct
-    # options after comma-splitting. Free-text columns should have high
-    # uniqueness. These checks catch misclassified question types.
-    MAX_EXPECTED_OPTIONS = 10
-    CLOSED_UNIQUENESS_THRESHOLD = 0.3
-    OPEN_UNIQUENESS_THRESHOLD = 0.3
+    # Open vs closed is decided purely by uniqueness ratio (n_unique /
+    # n_responses). Empirically (see analyse_open_closed_detector.py) a
+    # threshold of 0.2 separates the two classes well: closed columns sit
+    # well below it and free-text columns well above.
+    UNIQUENESS_RATIO_THRESHOLD = 0.2
+
+    def _uniqueness_ratio(col_id: str) -> tuple[int, int, float] | None:
+        """Return (n_unique, n_responses, ratio) for a column, or None if empty."""
+        if col_id not in responses_df.columns:
+            return None
+        series = responses_df[col_id].dropna().astype(str)
+        n_responses = len(series)
+        if n_responses == 0:
+            return None
+        n_unique = int(series.nunique())
+        return n_unique, n_responses, n_unique / n_responses
 
     def _check_looks_like_multichoice(
         col_id: str,
@@ -338,40 +348,22 @@ def validate_data(
         sheet_key: str,
         col_role: str,
     ) -> None:
-        """Warn if a column expected to be multichoice looks like free text."""
-        if col_id not in responses_df.columns:
+        """Warn if a closed column has a uniqueness ratio above the threshold."""
+        stats = _uniqueness_ratio(col_id)
+        if stats is None:
             return
-        series = responses_df[col_id].dropna().astype(str)
-        n_responses = len(series)
-        if n_responses == 0:
+        n_unique, n_responses, ratio = stats
+        if ratio <= UNIQUENESS_RATIO_THRESHOLD:
             return
         sheet_name = QU_SHEET_SPECS[sheet_key][0]
-
-        # Gather both signals, report as one warning
-        problems: list[str] = []
-
-        all_options: set[str] = set()
-        for cell in series:
-            all_options.update(item.strip() for item in cell.split(","))
-        if len(all_options) > MAX_EXPECTED_OPTIONS:
-            problems.append(
-                f"{len(all_options)} unique options after comma-split (expected ≤{MAX_EXPECTED_OPTIONS})"
-            )
-
-        n_unique = series.nunique()
-        ratio = n_unique / n_responses
-        if ratio > CLOSED_UNIQUENESS_THRESHOLD:
-            problems.append(
-                f"{n_unique}/{n_responses} responses are unique ({ratio:.0%}, expected ≤{CLOSED_UNIQUENESS_THRESHOLD:.0%})"
-            )
-
-        if problems:
-            msg = (
-                f'Column {col_id} (Q{q_num}, {col_role}) — on Q.U. sheet "{sheet_name}" — '
-                f"looks like free text, not multichoice: {'; '.join(problems)}"
-            )
-            print(f"\n  ⚠ {msg}")
-            issues.append(msg)
+        msg = (
+            f'Column {col_id} (Q{q_num}, {col_role}) — on Q.U. sheet "{sheet_name}" — '
+            f"looks like free text, not multichoice: "
+            f"{n_unique}/{n_responses} responses are unique "
+            f"({ratio:.0%}, expected ≤{UNIQUENESS_RATIO_THRESHOLD:.0%})"
+        )
+        print(f"\n  ⚠ {msg}")
+        issues.append(msg)
 
     def _check_looks_like_free_text(
         col_id: str,
@@ -379,25 +371,22 @@ def validate_data(
         sheet_key: str,
         col_role: str,
     ) -> None:
-        """Warn if a column expected to be free text looks like multichoice."""
-        if col_id not in responses_df.columns:
+        """Warn if an open column has a uniqueness ratio below the threshold."""
+        stats = _uniqueness_ratio(col_id)
+        if stats is None:
             return
-        series = responses_df[col_id].dropna().astype(str)
-        n_responses = len(series)
-        if n_responses == 0:
+        n_unique, n_responses, ratio = stats
+        if ratio >= UNIQUENESS_RATIO_THRESHOLD:
             return
         sheet_name = QU_SHEET_SPECS[sheet_key][0]
-        n_unique = series.nunique()
-        ratio = n_unique / n_responses
-        if ratio < OPEN_UNIQUENESS_THRESHOLD:
-            msg = (
-                f'Column {col_id} (Q{q_num}, {col_role}) — on Q.U. sheet "{sheet_name}" — '
-                f"only {n_unique}/{n_responses} responses are unique ({ratio:.0%}) — "
-                f"expected >{OPEN_UNIQUENESS_THRESHOLD:.0%} for free text. "
-                f'Should this be on the "Multiple Choice" sheet instead?'
-            )
-            print(f"\n  ⚠ {msg}")
-            issues.append(msg)
+        msg = (
+            f'Column {col_id} (Q{q_num}, {col_role}) — on Q.U. sheet "{sheet_name}" — '
+            f"only {n_unique}/{n_responses} responses are unique ({ratio:.0%}) — "
+            f"expected >{UNIQUENESS_RATIO_THRESHOLD:.0%} for free text. "
+            f'Should this be on the "Multiple Choice" sheet instead?'
+        )
+        print(f"\n  ⚠ {msg}")
+        issues.append(msg)
 
     for sheet_key in ("closed", "hybrid", "open"):
         df = question_sheets.get(sheet_key)

--- a/setup_consultation.py
+++ b/setup_consultation.py
@@ -636,7 +636,7 @@ def _clean_text_column(series: pd.Series) -> pd.Series:
     series = series.astype(str).str.encode("ascii", "ignore").str.decode("ascii")
     for bad_string in CHARACTERS_TO_REMOVE:
         series = series.apply(lambda x, bs=bad_string: x.replace(bs, " "))
-    return series
+    return series.str.strip()
 
 
 def create_question_inputs(

--- a/setup_consultation.py
+++ b/setup_consultation.py
@@ -326,7 +326,7 @@ def validate_data(
 
     # ── Column data type checks ─────────────────────────────────────────
     # Open vs closed is decided purely by uniqueness ratio (n_unique /
-    # n_responses). Empirically (see analyse_open_closed_detector.py) a
+    # n_responses). Empirically  a
     # threshold of 0.2 separates the two classes well: closed columns sit
     # well below it and free-text columns well above.
     UNIQUENESS_RATIO_THRESHOLD = 0.2

--- a/tests/test_setup_consultation.py
+++ b/tests/test_setup_consultation.py
@@ -531,3 +531,29 @@ def test_create_question_inputs_deduplicates_hybrid_options(tmp_path):
     rows = [json.loads(line) for line in lines]
     assert rows[0]["options"] == ["Strongly agree", "Agree"]
     assert rows[1]["options"] == ["Disagree"]
+
+
+def test_create_question_inputs_strips_response_text_whitespace(tmp_path):
+    """Open question: leading/trailing whitespace is stripped from response text."""
+    df = pd.DataFrame(
+        {
+            "themefinder_id": [1, 2, 3],
+            "C": [
+                "  leading spaces",
+                "trailing spaces   ",
+                "\t\nwhitespace surrounded by newlines and tabs\n  ",
+            ],
+        }
+    )
+    questions = [
+        {"question_number": 1, "column_name": "C", "question_text": "Why?"}
+    ]
+    create_question_inputs(df, questions, "open", tmp_path)
+
+    lines = (
+        (tmp_path / "question_part_1" / "responses.jsonl").read_text().splitlines()
+    )
+    rows = [json.loads(line) for line in lines]
+    assert rows[0]["text"] == "leading spaces"
+    assert rows[1]["text"] == "trailing spaces"
+    assert rows[2]["text"] == "whitespace surrounded by newlines and tabs"

--- a/tests/test_setup_consultation.py
+++ b/tests/test_setup_consultation.py
@@ -224,21 +224,17 @@ def _responses(data: dict, n: int = 10) -> tuple[pd.DataFrame, dict[str, str]]:
 
 def test_validate_data_clean(capsys):
     """Happy path: well-formed data produces no issues."""
-    n = 10
+    n = 30
     df, headers = _responses(
         {
             "Response ID": list(range(n)),
             "Please tell us your views on this proposal": [
                 f"Unique response number {i} about the policy topic" for i in range(n)
             ],
-            "Which option best describes your view": [
-                "Agree",
-                "Disagree",
-                "Strongly agree",
-            ]
-            * 3
-            + ["Agree"],
-            "Region": ["North"] * 5 + ["South"] * 5,
+            "Which option best describes your view": (
+                ["Agree", "Disagree", "Strongly agree"] * (n // 3)
+            ),
+            "Region": ["North"] * (n // 2) + ["South"] * (n - n // 2),
         },
         n,
     )

--- a/tests/test_setup_consultation.py
+++ b/tests/test_setup_consultation.py
@@ -541,14 +541,10 @@ def test_create_question_inputs_strips_response_text_whitespace(tmp_path):
             ],
         }
     )
-    questions = [
-        {"question_number": 1, "column_name": "C", "question_text": "Why?"}
-    ]
+    questions = [{"question_number": 1, "column_name": "C", "question_text": "Why?"}]
     create_question_inputs(df, questions, "open", tmp_path)
 
-    lines = (
-        (tmp_path / "question_part_1" / "responses.jsonl").read_text().splitlines()
-    )
+    lines = (tmp_path / "question_part_1" / "responses.jsonl").read_text().splitlines()
     rows = [json.loads(line) for line in lines]
     assert rows[0]["text"] == "leading spaces"
     assert rows[1]["text"] == "trailing spaces"


### PR DESCRIPTION
## Summary
- Strip leading/trailing whitespace from free-text responses in `_clean_text_column` (also trims trailing whitespace left by the `_x000D_` → space substitution).
- Replace the old open/closed validation heuristics (comma-split option count + separate 0.3 thresholds) with a single uniqueness-ratio check at `UNIQUENESS_RATIO_THRESHOLD = 0.2`. Closed columns with ratio above 0.2 and open columns with ratio below 0.2 are flagged. Threshold chosen from an analysis across all consultations (best single-feature accuracy ~97%).
- Extract a shared `_uniqueness_ratio` helper so `_check_looks_like_multichoice` and `_check_looks_like_free_text` use the same implementation.

## Test plan
- [x] `uv run pytest tests/` (107 passed)
- [x] Happy-path validation fixture bumped from 10 → 30 rows so the closed column (3 options) sits cleanly below the new 20% threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)