### PR TITLE
Switch evals/benchmark to LiteLLM gateway, add dynamic model discovery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,12 @@
-# These are for Azure Open AI endpoint
-# Change the variables for your LLM of choice
-AZURE_OPENAI_API_KEY=
-AZURE_OPENAI_ENDPOINT=
-OPENAI_API_VERSION=
-AUTO_EVAL_4_1_SWEDEN_DEPLOYMENT=
-AZURE_OPENAI_BASE_URL=
+# LLM gateway - all model access goes through this, no direct provider credentials
+LLM_GATEWAY_URL=
+CONSULT_EVAL_LITELLM_API_KEY=
+# For the auto-eval judge/scoring model
+# Prefilled with a known working value, 
+# otherwise it fails silently later.
+# TODO: revisit as part of the broader 
+# code refactor in a later ticket.
+AUTO_EVAL_4_1_SWEDEN_DEPLOYMENT=gpt-4.1-sweden-2025-03
 
 # Bucket name for running evaluations
 THEMEFINDER_S3_BUCKET_NAME=
@@ -14,7 +16,3 @@ LANGFUSE_SECRET_KEY=
 LANGFUSE_PUBLIC_KEY=
 LANGFUSE_BASE_URL=
 LANGFUSE_PROJECT_ID=
-
-# GCP Vertex AI (for Gemini and Claude benchmarks)
-GOOGLE_CLOUD_PROJECT=
-GOOGLE_APPLICATION_CREDENTIALS=

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -70,11 +70,6 @@ jobs:
       - name: Run eval
         id: eval
         env:
-          AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
-          AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
-          LOCAI_ENDPOINT: ${{ secrets.LOCAI_ENDPOINT }}
-          LOCAI_API_KEY: ${{ secrets.LOCAI_API_KEY }}
-          OPENAI_API_VERSION: ${{ secrets.AZURE_OPENAI_API_VERSION }}
           LLM_GATEWAY_URL: ${{ secrets.LLM_GATEWAY_URL }}
           CONSULT_EVAL_LITELLM_API_KEY: ${{ secrets.CONSULT_EVAL_LITELLM_API_KEY }}
           AUTO_EVAL_4_1_SWEDEN_DEPLOYMENT: ${{ secrets.AUTO_EVAL_4_1_SWEDEN_DEPLOYMENT }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,8 +27,14 @@ jobs:
 
       - name: Run tests with Pytest
         run: |
-          uv run coverage run -m pytest -v -s
+          uv run coverage run -m pytest tests/ -v -s
 
       - name: Generate coverage report
         run: |
           uv run coverage report -m --fail-under=95
+
+      # TODO: not counted towards coverage yet - fold into the gate above
+      # once evals/ is refactored and has more tests.
+      - name: Run evals unit tests
+        run: |
+          uv run pytest evals/tests/ -v

--- a/evals/benchmark.py
+++ b/evals/benchmark.py
@@ -979,9 +979,7 @@ Examples:
     gateway_models = await utils_gateway.discover_chat_models()
 
     if args.models:
-        selected, missing, unhealthy = _select_named_models(
-            gateway_models, args.models
-        )
+        selected, missing, unhealthy = _select_named_models(gateway_models, args.models)
         if missing:
             available = sorted(m.name for m in gateway_models)
             console.print(

--- a/evals/benchmark.py
+++ b/evals/benchmark.py
@@ -213,7 +213,9 @@ class BenchmarkConfig:
             "refinement",
         ]
     )
-    judge_model: str | None = None  # Gateway model name for judge LLM (e.g. "gpt-4o-uk")
+    judge_model: str | None = (
+        None  # Gateway model name for judge LLM (e.g. "gpt-4o-uk")
+    )
 
 
 @dataclass
@@ -859,7 +861,9 @@ def _validate_selector_args(args: argparse.Namespace) -> str | None:
 
 def _resolve_selected_models(
     args: argparse.Namespace, gateway_models: list[utils_gateway.GatewayModel]
-) -> tuple[list[utils_gateway.GatewayModel], list[str], list[utils_gateway.GatewayModel]]:
+) -> tuple[
+    list[utils_gateway.GatewayModel], list[str], list[utils_gateway.GatewayModel]
+]:
     """Apply --models/--family/--all to an already-fetched gateway model list.
 
     --models is an explicit request by exact name: the user named this model
@@ -981,7 +985,9 @@ Examples:
 
     if missing:
         available = sorted(m.name for m in gateway_models)
-        console.print(f"[red]No matching models: {missing}. Available: {available}[/red]")
+        console.print(
+            f"[red]No matching models: {missing}. Available: {available}[/red]"
+        )
         return
 
     for gm in unhealthy:

--- a/evals/benchmark.py
+++ b/evals/benchmark.py
@@ -152,8 +152,7 @@ class ModelConfig:
     """Configuration for a single model variant, resolved from the gateway.
 
     `name` is the gateway's model_group name — used both for display and as
-    the `model=` value sent to the gateway, since dynamic discovery means
-    there's no separate internal alias to translate through anymore.
+    the `model=` value sent to the gateway.
     """
 
     name: str

--- a/evals/benchmark.py
+++ b/evals/benchmark.py
@@ -859,37 +859,34 @@ def _validate_selector_args(args: argparse.Namespace) -> str | None:
     return None
 
 
-def _resolve_selected_models(
-    args: argparse.Namespace, gateway_models: list[utils_gateway.GatewayModel]
+def _select_named_models(
+    gateway_models: list[utils_gateway.GatewayModel], names: list[str]
 ) -> tuple[
     list[utils_gateway.GatewayModel], list[str], list[utils_gateway.GatewayModel]
 ]:
-    """Apply --models/--family/--all to an already-fetched gateway model list.
+    """--models: exact-name lookup. Unhealthy matches are still selected (the
+    user asked for them by name) — just flagged for a warning, not dropped.
 
-    --models is an explicit request by exact name: the user named this model
-    deliberately, so an unhealthy match is still selected and just warned on
-    rather than silently dropped — surfacing the signal without overriding
-    their choice. --family/--all are broad, automatic selections where no
-    specific model was named, so excluding unhealthy models there is the
-    safer default (nothing explicit is being overridden by dropping them).
-
-    Returns (selected, missing, unhealthy) — plain data, caller decides how to
-    report it. `missing` is only ever populated for --models (unknown names).
-    `unhealthy` is the subset of `selected` still flagged unhealthy: always
-    empty for --family/--all (exclude_unhealthy already ran on that path), so
-    the caller doesn't need to know which selector mode produced `selected`
-    to know whether to warn — it just prints whatever's in the list.
+    Returns (selected, missing, unhealthy).
     """
-    if args.models:
-        selected, missing = utils_gateway.select_by_name(gateway_models, args.models)
-    else:
-        selected = utils_gateway.exclude_unhealthy(gateway_models)
-        if args.family:
-            selected = utils_gateway.filter_by_family(selected, args.family)
-        missing = []
+    found, missing = utils_gateway.select_by_name(gateway_models, names)
+    _, unhealthy = utils_gateway.split_unhealthy(found)
+    return found, missing, unhealthy
 
-    unhealthy = [m for m in selected if m.health == "unhealthy"]
-    return selected, missing, unhealthy
+
+def _select_healthy_models(
+    gateway_models: list[utils_gateway.GatewayModel], families: list[str] | None
+) -> tuple[list[utils_gateway.GatewayModel], list[utils_gateway.GatewayModel]]:
+    """--family/--all: broad selection, unhealthy models dropped (not just warned).
+
+    Returns (selected, excluded).
+    """
+    candidates = (
+        utils_gateway.filter_by_family(gateway_models, families)
+        if families
+        else gateway_models
+    )
+    return utils_gateway.split_unhealthy(candidates)
 
 
 async def main():
@@ -981,20 +978,29 @@ Examples:
         args.models = list(dict.fromkeys(args.models))
 
     gateway_models = await utils_gateway.discover_chat_models()
-    selected, missing, unhealthy = _resolve_selected_models(args, gateway_models)
 
-    if missing:
-        available = sorted(m.name for m in gateway_models)
-        console.print(
-            f"[red]No matching models: {missing}. Available: {available}[/red]"
+    if args.models:
+        selected, missing, unhealthy = _select_named_models(
+            gateway_models, args.models
         )
-        return
-
-    for gm in unhealthy:
-        console.print(
-            f"[yellow]Warning: {gm.name} is reported unhealthy by the gateway "
-            "— proceeding anyway[/yellow]"
-        )
+        if missing:
+            available = sorted(m.name for m in gateway_models)
+            console.print(
+                f"[red]No matching models: {missing}. Available: {available}[/red]"
+            )
+            return
+        for gm in unhealthy:
+            console.print(
+                f"[yellow]Warning: {gm.name} is reported unhealthy by the gateway "
+                "— proceeding anyway[/yellow]"
+            )
+    else:
+        selected, excluded = _select_healthy_models(gateway_models, args.family)
+        if excluded:
+            console.print(
+                f"[dim]Excluded {len(excluded)} unhealthy model(s), not run: "
+                f"{[m.name for m in excluded]}[/dim]"
+            )
 
     if not selected:
         console.print("[red]No models matched the given selector.[/red]")

--- a/evals/benchmark.py
+++ b/evals/benchmark.py
@@ -1,29 +1,23 @@
 #!/usr/bin/env python
 """Multi-model benchmark runner for ThemeFinder evaluations.
 
-Runs evaluations across Azure OpenAI and GCP Vertex AI models (Gemini + Claude)
-with configurable hyperparameters, tracks results in Langfuse, and generates
-summary tables.
+Runs evaluations across chat models discovered dynamically from the LLM
+gateway, with configurable hyperparameters, tracks results in Langfuse, and
+generates summary tables.
 
 Usage:
-    # All models (default)
-    uv run python benchmark.py --dataset housing_S --runs 3
+    # Every healthy chat model on the gateway
+    uv run python benchmark.py --all --dataset housing_S --runs 3
 
-    # Azure OpenAI models only
-    uv run python benchmark.py --provider azure --dataset housing_S
+    # One or more vendor families
+    uv run python benchmark.py --family gpt --dataset housing_S
+    uv run python benchmark.py --family gemini claude --dataset housing_S
 
-    # locai models only
-    uv run python benchmark.py --provider locai --dataset housing_S
-
-    # Vertex AI models only (Gemini + Claude)
-    uv run python benchmark.py --provider vertex --dataset bbc_mission_public_purposes
-
-    # Specific models across providers
-    uv run python benchmark.py --models gpt-4o gemini-2.5-flash claude-haiku-4.5
+    # Specific models by exact gateway name
+    uv run python benchmark.py --models gpt-4o-uk gemini-3.5-flash-uk
 
 Requires:
     - LLM_GATEWAY_URL and CONSULT_EVAL_LITELLM_API_KEY env vars
-    - Vertex: Not yet implemented (TODO)
 """
 
 import argparse
@@ -36,13 +30,13 @@ import time
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from datetime import datetime
-from enum import Enum
 from pathlib import Path
 from typing import Any
 
 import dotenv
 import nest_asyncio
 import pandas as pd
+import utils_gateway
 from rich.console import Console
 from rich.table import Table
 from themefinder.llm import OpenAILLM
@@ -65,15 +59,6 @@ except ImportError:
 # Fix DNS resolution issues with gRPC 1.58.0+ (must be set before gRPC imports)
 # Switches from buggy C-ares resolver to native resolver
 os.environ.setdefault("GRPC_DNS_RESOLVER", "native")
-
-
-class LLMProvider(str, Enum):
-    """Supported LLM providers."""
-
-    AZURE_OPENAI = "azure_openai"
-    VERTEX_GEMINI = "vertex_gemini"
-    VERTEX_CLAUDE = "vertex_claude"
-    LOCAI = "locai"
 
 
 import langfuse_utils  # noqa: E402
@@ -164,38 +149,25 @@ class BenchmarkLogFilter(logging.Filter):
 
 @dataclass
 class ModelConfig:
-    """Configuration for a single model variant.
+    """Configuration for a single model variant, resolved from the gateway.
 
-    Supports Azure OpenAI, GCP Vertex AI (Gemini), and Vertex AI (Claude) models.
+    `name` is the gateway's model_group name — used both for display and as
+    the `model=` value sent to the gateway, since dynamic discovery means
+    there's no separate internal alias to translate through anymore.
     """
 
-    name: str  # Display name for results
-    deployment: str  # Model ID (Azure deployment name or Vertex model ID)
-    provider: LLMProvider = LLMProvider.AZURE_OPENAI
-
-    # Azure-specific
-    reasoning_effort: str | None = None  # For gpt-5 models: low, medium, high
-
-    # Vertex AI-specific
-    project_id: str | None = None  # Falls back to GOOGLE_CLOUD_PROJECT env var
-    location: str = "global"  # Vertex AI region
-    thinking_budget: int | None = None  # For Gemini/Claude thinking tokens (e.g., 2048)
-
-    # Common
+    name: str
+    reasoning_effort: str | None = None  # low/medium/high, for reasoning-capable models
     temperature: float = 0.0
     timeout: int = 600  # 10 min default
 
     def create_llm(self) -> OpenAILLM:
         """Create an OpenAILLM instance via the LLM gateway."""
-        if self.provider in (LLMProvider.VERTEX_GEMINI, LLMProvider.VERTEX_CLAUDE):
-            raise NotImplementedError(
-                f"TODO: implement OpenAILLM adapter for {self.provider.value}"
-            )
         request_kwargs: dict[str, Any] = {}
         if not self.reasoning_effort:
             request_kwargs["temperature"] = self.temperature
         return OpenAILLM(
-            model=self.deployment,
+            model=self.name,
             request_kwargs=request_kwargs,
             base_url=os.getenv("LLM_GATEWAY_URL"),
             api_key=os.getenv("CONSULT_EVAL_LITELLM_API_KEY"),
@@ -207,89 +179,23 @@ class ModelConfig:
         """Tag for Langfuse identification."""
         if self.reasoning_effort:
             return f"{self.name}_{self.reasoning_effort}"
-        if self.thinking_budget:
-            return f"{self.name}_thinking{self.thinking_budget}"
         return self.name
 
 
-# All available model configurations by provider
-# Azure OpenAI models - use dated versions that support structured outputs
-AZURE_MODELS = [
-    ModelConfig(name="gpt-4o", deployment="gpt-4o-2024-08-06-sweden"),
-    ModelConfig(name="gpt-4.1", deployment="gpt-4.1-sweden-2025-03"),
-    ModelConfig(name="gpt-4.1-mini", deployment="gpt-4.1-mini"),
-    ModelConfig(name="gpt-5-nano", deployment="gpt-5-nano", reasoning_effort="low"),
-    ModelConfig(name="gpt-5-mini", deployment="gpt-5-mini", reasoning_effort="low"),
-]
+def _to_model_configs(
+    gateway_model: utils_gateway.GatewayModel, reasoning_efforts: list[str]
+) -> list[ModelConfig]:
+    """Expand one gateway model into one ModelConfig per requested effort level.
 
-# Vertex AI models (Gemini and Claude)
-# Requires: uv pip install -e ".[vertex]" and GOOGLE_CLOUD_PROJECT env var
-VERTEX_MODELS = [
-    # Gemini models - standard (no thinking)
-    ModelConfig(
-        name="gemini-2.5-flash",
-        deployment="gemini-2.5-flash",
-        provider=LLMProvider.VERTEX_GEMINI,
-    ),
-    ModelConfig(
-        name="gemini-2.5-flash-lite",
-        deployment="gemini-2.5-flash-lite",
-        provider=LLMProvider.VERTEX_GEMINI,
-    ),
-    ModelConfig(
-        name="gemini-3-flash-preview",
-        deployment="gemini-3-flash-preview",
-        provider=LLMProvider.VERTEX_GEMINI,
-    ),
-    # Gemini thinking models removed: thinking_budget conflicts with
-    # structured output in google-genai SDK, causing empty {} responses.
-    # See: https://github.com/googleapis/python-genai/issues/782
-    # ModelConfig(
-    #     name="gemini-2.5-pro",
-    #     deployment="gemini-2.5-pro",
-    #     provider=LLMProvider.VERTEX_GEMINI,
-    # ),
-    # Claude models via Vertex AI Model Garden - standard (no thinking)
-    ModelConfig(
-        name="claude-haiku-4.5",
-        deployment="claude-haiku-4-5@20251001",
-        provider=LLMProvider.VERTEX_CLAUDE,
-    ),
-    # Claude thinking model disabled: thinking_budget conflicts with
-    # tool_choice in ThemeFinder pipeline (structured output requires forced tool use).
-    # See: "Thinking may not be enabled when tool_choice forces tool use."
-    # ModelConfig(
-    #     name="claude-haiku-4.5-thinking",
-    #     deployment="claude-haiku-4-5@20251001",
-    #     provider=LLMProvider.VERTEX_CLAUDE,
-    #     thinking_budget=2048,
-    # ),
-    # ModelConfig(
-    #     name="claude-sonnet-4.5",
-    #     deployment="claude-sonnet-4-5@20250929",
-    #     provider=LLMProvider.VERTEX_CLAUDE,
-    # ),
-]
-
-# Locai models
-LOCAI_MODELS = [
-    ModelConfig(
-        name="locailabs/locai-l1-large-2011",
-        deployment="locailabs/locai-l1-large-2011",
-        provider=LLMProvider.LOCAI,
-    ),
-]
-
-# Combined model registry by provider
-MODEL_REGISTRY: dict[str, list[ModelConfig]] = {
-    "azure": AZURE_MODELS,
-    "vertex": VERTEX_MODELS,
-    "locai": LOCAI_MODELS,
-    "all": AZURE_MODELS + VERTEX_MODELS + LOCAI_MODELS,
-}
-
-# Default models (Azure) for backwards compatibility
-DEFAULT_MODELS = AZURE_MODELS
+    Only reasoning-capable models are affected — everything else always gets
+    exactly one config, regardless of --reasoning-effort.
+    """
+    if not gateway_model.supports_reasoning:
+        return [ModelConfig(name=gateway_model.name)]
+    return [
+        ModelConfig(name=gateway_model.name, reasoning_effort=effort)
+        for effort in reasoning_efforts
+    ]
 
 
 @dataclass
@@ -297,7 +203,7 @@ class BenchmarkConfig:
     """Configuration for a benchmark run."""
 
     dataset: str
-    models: list[ModelConfig] = field(default_factory=lambda: DEFAULT_MODELS)
+    models: list[ModelConfig]
     runs_per_model: int = 5
     evals: list[str] = field(
         default_factory=lambda: [
@@ -307,9 +213,7 @@ class BenchmarkConfig:
             "refinement",
         ]
     )
-    judge_model: str | None = (
-        None  # Azure deployment name for judge LLM (e.g. "gpt-4o-2024-08-06")
-    )
+    judge_model: str | None = None  # Gateway model name for judge LLM (e.g. "gpt-4o-uk")
 
 
 @dataclass
@@ -390,55 +294,53 @@ class BenchmarkRunner:
         )
         runs_per_model = self.config.runs_per_model * len(self.config.evals)
 
-        # Group models by deployment to avoid rate limit contention
-        deployment_groups: dict[str, list[ModelConfig]] = {}
+        # Group by name to avoid rate-limit contention: --reasoning-effort can
+        # produce multiple ModelConfigs sharing one gateway model (e.g. the
+        # same model at low/medium/high), and those share one underlying
+        # deployment, so they're run sequentially within a group rather than
+        # firing concurrent requests at the same rate-limited resource.
+        # Distinct models (different groups) still run fully in parallel.
+        name_groups: dict[str, list[ModelConfig]] = {}
         for model in self.config.models:
-            if model.deployment not in deployment_groups:
-                deployment_groups[model.deployment] = []
-            deployment_groups[model.deployment].append(model)
+            name_groups.setdefault(model.name, []).append(model)
 
         console.print(
             f"\n[bold cyan]Starting Benchmark: {self.benchmark_id}[/bold cyan]"
         )
         console.print(f"  Dataset: {self.config.dataset}")
         console.print(
-            f"  Models: {len(self.config.models)} across {len(deployment_groups)} deployments"
-        )
-        console.print(
-            "  Strategy: [bold]parallel by deployment, sequential within[/bold]"
+            f"  Models: {len(self.config.models)} across {len(name_groups)} distinct"
         )
         console.print(f"  Runs per model: {self.config.runs_per_model}")
         console.print(f"  Evals: {', '.join(self.config.evals)}")
         console.print(f"  Total runs: {total_runs} ({runs_per_model} per model)\n")
 
-        # Run deployment groups in parallel, models within each group sequentially
-        deployment_tasks = [
-            self._run_deployment_group(deployment, models)
-            for deployment, models in deployment_groups.items()
+        # Run distinct-model groups in parallel; variants within a group sequentially
+        group_tasks = [
+            self._run_model_group(name, models) for name, models in name_groups.items()
         ]
-        results = await asyncio.gather(*deployment_tasks, return_exceptions=True)
+        results = await asyncio.gather(*group_tasks, return_exceptions=True)
 
-        # Report any deployment-level failures
-        for deployment, result in zip(deployment_groups.keys(), results):
+        # Report any group-level failures
+        for name, result in zip(name_groups.keys(), results):
             if isinstance(result, Exception):
-                console.print(f"[bold red][{deployment}] FAILED: {result}[/bold red]")
+                console.print(f"[bold red][{name}] FAILED: {result}[/bold red]")
 
         return self.results
 
-    async def _run_deployment_group(
-        self, deployment: str, models: list[ModelConfig]
+    async def _run_model_group(
+        self, name: str, models: list[ModelConfig]
     ) -> list[RunResult]:
-        """Run all models for a deployment sequentially to avoid rate limit contention."""
-        console.print(
-            f"[dim][{deployment}] Starting {len(models)} model variant(s)[/dim]"
-        )
-        group_results = []
+        """Run all variants (e.g. reasoning-effort levels) of one model sequentially.
 
+        Sequential on purpose: variants share one underlying gateway
+        deployment, so running them concurrently would contend for that
+        deployment's rate limit instead of just this group's own pacing.
+        """
+        group_results = []
         for model_config in models:
             model_results = await self._run_model(model_config)
             group_results.extend(model_results)
-
-        console.print(f"[bold green][{deployment}] All variants complete![/bold green]")
         return group_results
 
     async def _run_model(self, model_config: ModelConfig) -> list[RunResult]:
@@ -565,7 +467,6 @@ class BenchmarkRunner:
                 "benchmark_id": self.benchmark_id,
                 "model": model_config.name,
                 "model_tag": model_config.tag,
-                "deployment": model_config.deployment,
                 "reasoning_effort": model_config.reasoning_effort,
                 "run_number": run_number,
                 "dataset": self.config.dataset,
@@ -699,11 +600,7 @@ class BenchmarkRunner:
             "evals": self.config.evals,
             "judge_model": self.config.judge_model,
             "models": [
-                {
-                    "name": m.name,
-                    "deployment": m.deployment,
-                    "reasoning_effort": m.reasoning_effort,
-                }
+                {"name": m.name, "reasoning_effort": m.reasoning_effort}
                 for m in self.config.models
             ],
         }
@@ -940,29 +837,78 @@ def print_cost_summary(cost_df: pd.DataFrame) -> None:
     console.print(table)
 
 
+def _apply_quick_preset(args: argparse.Namespace) -> None:
+    """Apply --quick's fully self-contained preset, overriding any other selector."""
+    if not args.quick:
+        return
+    args.dataset = "gambling_XS"
+    args.runs = 1
+    # TODO: hardcoded to replicate existing behaviour as-is. Discuss what we
+    # actually want --quick to run and make this configurable accordingly.
+    args.models = ["gpt-4.1-sweden-2025-03"]
+    args.family = None
+    args.all = False
+
+
+def _validate_selector_args(args: argparse.Namespace) -> str | None:
+    """Return an error message if not exactly one of --models/--family/--all was given."""
+    if sum([bool(args.models), bool(args.family), args.all]) != 1:
+        return "Exactly one of --models, --family, or --all is required."
+    return None
+
+
+def _resolve_selected_models(
+    args: argparse.Namespace, gateway_models: list[utils_gateway.GatewayModel]
+) -> tuple[list[utils_gateway.GatewayModel], list[str], list[utils_gateway.GatewayModel]]:
+    """Apply --models/--family/--all to an already-fetched gateway model list.
+
+    --models is an explicit request by exact name: the user named this model
+    deliberately, so an unhealthy match is still selected and just warned on
+    rather than silently dropped — surfacing the signal without overriding
+    their choice. --family/--all are broad, automatic selections where no
+    specific model was named, so excluding unhealthy models there is the
+    safer default (nothing explicit is being overridden by dropping them).
+
+    Returns (selected, missing, unhealthy) — plain data, caller decides how to
+    report it. `missing` is only ever populated for --models (unknown names).
+    `unhealthy` is the subset of `selected` still flagged unhealthy: always
+    empty for --family/--all (exclude_unhealthy already ran on that path), so
+    the caller doesn't need to know which selector mode produced `selected`
+    to know whether to warn — it just prints whatever's in the list.
+    """
+    if args.models:
+        selected, missing = utils_gateway.select_by_name(gateway_models, args.models)
+    else:
+        selected = utils_gateway.exclude_unhealthy(gateway_models)
+        if args.family:
+            selected = utils_gateway.filter_by_family(selected, args.family)
+        missing = []
+
+    unhealthy = [m for m in selected if m.health == "unhealthy"]
+    return selected, missing, unhealthy
+
+
 async def main():
     """Main entry point."""
     dotenv.load_dotenv()
 
     parser = argparse.ArgumentParser(
-        description="Run ThemeFinder benchmark across Azure and Vertex AI models",
+        description="Run ThemeFinder benchmark across gateway-discovered chat models",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  # Run all models (default)
-  uv run python benchmark.py --dataset housing_S --runs 3
+  # Every healthy chat model on the gateway
+  uv run python benchmark.py --all --dataset housing_S --runs 3
 
-  # Run Azure models only
-  uv run python benchmark.py --provider azure --dataset housing_S
+  # One or more vendor families
+  uv run python benchmark.py --family gpt --dataset housing_S
+  uv run python benchmark.py --family gemini claude --dataset housing_S
 
-  # Run Vertex AI models only (Gemini + Claude)
-  uv run python benchmark.py --provider vertex --dataset bbc_mission_public_purposes
-
-  # Run specific models by name
-  uv run python benchmark.py --models gpt-4o gemini-2.5-flash --runs 2
+  # Specific models by exact gateway name
+  uv run python benchmark.py --models gpt-4o-uk gemini-3.5-flash-uk --runs 2
 
   # Run only mapping evals
-  uv run python benchmark.py --evals mapping
+  uv run python benchmark.py --all --evals mapping
         """,
     )
     parser.add_argument(
@@ -983,71 +929,74 @@ Examples:
         help="Evaluations to run (default: all)",
     )
     parser.add_argument(
-        "--provider",
-        choices=["azure", "vertex", "locai", "all"],
-        default="all",
-        help="Provider to use: azure, vertex, locai, or all (default)",
-    )
-    parser.add_argument(
         "--models",
         nargs="+",
-        help="Specific model names/tags to run (overrides --provider)",
+        help="Exact gateway model name(s) to run",
     )
     parser.add_argument(
-        "--location",
-        default="global",
-        help="Vertex AI location (default: global)",
+        "--family",
+        nargs="+",
+        choices=utils_gateway.KNOWN_FAMILIES,
+        help="Vendor famil(y/ies) to run, e.g. --family gemini claude",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Run every healthy chat model discovered on the gateway",
+    )
+    parser.add_argument(
+        "--reasoning-effort",
+        nargs="+",
+        choices=["low", "medium", "high"],
+        default=["low"],
+        help="Reasoning effort level(s) to run for reasoning-capable models "
+        "(default: low). No effect on models that don't support reasoning; "
+        "passing multiple levels runs each as a separate model variant.",
     )
     parser.add_argument(
         "--judge-model",
         default=None,
-        help="Azure deployment name for judge LLM (e.g. gpt-4o-2024-08-06). If set, judge evaluations use this model instead of the task model.",
+        help="Gateway model name for judge LLM (e.g. gpt-4o-uk). If set, judge evaluations use this model instead of the task model.",
     )
     parser.add_argument(
         "--quick",
         action="store_true",
-        help="Quick CI smoke test: gambling_XS dataset, 1 run, azure provider, gpt-4.1 only.",
+        help="Quick CI smoke test: gambling_XS dataset, 1 run, gpt-4.1-sweden-2025-03 only.",
     )
     args = parser.parse_args()
 
-    # Apply --quick preset (overrides other args)
-    if args.quick:
-        args.dataset = "gambling_XS"
-        args.runs = 1
-        args.provider = "azure"
-        args.models = ["gpt-4.1"]
+    _apply_quick_preset(args)
 
-    # Get models based on provider or specific model names
+    selector_error = _validate_selector_args(args)
+    if selector_error:
+        parser.error(selector_error)
+
+    # Dedupe --models so a copy-paste typo can't produce two variants of the
+    # same model running concurrently against each other.
     if args.models:
-        # Filter from all available models by name/tag
-        all_models = MODEL_REGISTRY["all"]
-        models = [
-            m for m in all_models if m.name in args.models or m.tag in args.models
-        ]
-        if not models:
-            available = sorted(set(m.name for m in all_models))
-            console.print(f"[red]No matching models. Available: {available}[/red]")
-            return
-    else:
-        # Use provider-based selection
-        models = MODEL_REGISTRY.get(args.provider, MODEL_REGISTRY["all"])
+        args.models = list(dict.fromkeys(args.models))
 
-    # Apply location override for Vertex models
-    if args.location != "global":
-        models = [
-            ModelConfig(
-                name=m.name,
-                deployment=m.deployment,
-                provider=m.provider,
-                reasoning_effort=m.reasoning_effort,
-                location=args.location,
-                temperature=m.temperature,
-                timeout=m.timeout,
-            )
-            if m.provider in (LLMProvider.VERTEX_GEMINI, LLMProvider.VERTEX_CLAUDE)
-            else m
-            for m in models
-        ]
+    gateway_models = await utils_gateway.discover_chat_models()
+    selected, missing, unhealthy = _resolve_selected_models(args, gateway_models)
+
+    if missing:
+        available = sorted(m.name for m in gateway_models)
+        console.print(f"[red]No matching models: {missing}. Available: {available}[/red]")
+        return
+
+    for gm in unhealthy:
+        console.print(
+            f"[yellow]Warning: {gm.name} is reported unhealthy by the gateway "
+            "— proceeding anyway[/yellow]"
+        )
+
+    if not selected:
+        console.print("[red]No models matched the given selector.[/red]")
+        return
+
+    models = [
+        mc for gm in selected for mc in _to_model_configs(gm, args.reasoning_effort)
+    ]
 
     config = BenchmarkConfig(
         dataset=args.dataset,
@@ -1060,12 +1009,8 @@ Examples:
     runner = BenchmarkRunner(config)
 
     # Print configuration summary
-    providers_used = sorted(set(m.provider.value for m in models))
     console.print("\n[bold cyan]ThemeFinder Benchmark[/bold cyan]")
-    console.print(f"  Provider(s): {', '.join(providers_used)}")
     console.print(f"  Models: {[m.name for m in models]}")
-    if any(m.provider != LLMProvider.AZURE_OPENAI for m in models):
-        console.print(f"  Vertex location: {args.location}")
     console.print()
 
     try:

--- a/evals/benchmark.py
+++ b/evals/benchmark.py
@@ -165,11 +165,12 @@ class ModelConfig:
         request_kwargs: dict[str, Any] = {}
         if not self.reasoning_effort:
             request_kwargs["temperature"] = self.temperature
+        base_url, api_key = utils_gateway.gateway_credentials()
         return OpenAILLM(
             model=self.name,
             request_kwargs=request_kwargs,
-            base_url=os.getenv("LLM_GATEWAY_URL"),
-            api_key=os.getenv("CONSULT_EVAL_LITELLM_API_KEY"),
+            base_url=base_url,
+            api_key=api_key,
             timeout=self.timeout,
         )
 
@@ -485,11 +486,12 @@ class BenchmarkRunner:
         # Create dedicated judge LLM if configured (separates judge from task model)
         judge_llm = None
         if self.config.judge_model:
+            base_url, api_key = utils_gateway.gateway_credentials()
             judge_llm = OpenAILLM(
                 model=self.config.judge_model,
                 request_kwargs={"temperature": 0},
-                base_url=os.getenv("LLM_GATEWAY_URL"),
-                api_key=os.getenv("CONSULT_EVAL_LITELLM_API_KEY"),
+                base_url=base_url,
+                api_key=api_key,
                 timeout=600,
             )
 

--- a/evals/eval_condensation.py
+++ b/evals/eval_condensation.py
@@ -12,6 +12,7 @@ from datetime import datetime
 import dotenv
 import langfuse_utils
 import pandas as pd
+import utils_gateway
 from datasets import DatasetConfig, load_local_data
 from evaluators import calculate_redundancy_score, create_condensation_quality_evaluator
 from themefinder import theme_condensation
@@ -51,11 +52,12 @@ async def evaluate_condensation(
 
     # Use provided LLM or create new one
     if llm is None:
+        base_url, api_key = utils_gateway.gateway_credentials()
         llm = OpenAILLM(
             model=os.getenv("AUTO_EVAL_4_1_SWEDEN_DEPLOYMENT"),
             request_kwargs={"temperature": 0},
-            base_url=os.getenv("LLM_GATEWAY_URL"),
-            api_key=os.getenv("CONSULT_EVAL_LITELLM_API_KEY"),
+            base_url=base_url,
+            api_key=api_key,
         )
 
     # Select judge LLM (falls back to task LLM if not provided)

--- a/evals/eval_generation.py
+++ b/evals/eval_generation.py
@@ -15,6 +15,7 @@ from functools import partial
 import dotenv
 import langfuse_utils
 import pandas as pd
+import utils_gateway
 from datasets import DatasetConfig, load_local_data
 from evaluators import (
     create_coverage_evaluator,
@@ -63,11 +64,12 @@ async def evaluate_generation(
 
     # Use provided LLM or create new one
     if llm is None:
+        base_url, api_key = utils_gateway.gateway_credentials()
         llm = OpenAILLM(
             model=os.getenv("AUTO_EVAL_4_1_SWEDEN_DEPLOYMENT"),
             request_kwargs={"temperature": 0},
-            base_url=os.getenv("LLM_GATEWAY_URL"),
-            api_key=os.getenv("CONSULT_EVAL_LITELLM_API_KEY"),
+            base_url=base_url,
+            api_key=api_key,
         )
 
     # Branch: Langfuse dataset vs local fallback

--- a/evals/eval_mapping.py
+++ b/evals/eval_mapping.py
@@ -11,6 +11,7 @@ from datetime import datetime
 import dotenv
 import langfuse_utils
 import pandas as pd
+import utils_gateway
 from datasets import DatasetConfig, load_local_data
 from evaluators import mapping_f1_evaluator
 from metrics import calculate_mapping_metrics
@@ -53,11 +54,12 @@ async def evaluate_mapping(
 
     # Use provided LLM or create new one
     if llm is None:
+        base_url, api_key = utils_gateway.gateway_credentials()
         llm = OpenAILLM(
             model=os.getenv("AUTO_EVAL_4_1_SWEDEN_DEPLOYMENT"),
             request_kwargs={"temperature": 0},
-            base_url=os.getenv("LLM_GATEWAY_URL"),
-            api_key=os.getenv("CONSULT_EVAL_LITELLM_API_KEY"),
+            base_url=base_url,
+            api_key=api_key,
         )
 
     # Branch: Langfuse dataset vs local fallback

--- a/evals/eval_refinement.py
+++ b/evals/eval_refinement.py
@@ -11,6 +11,7 @@ from datetime import datetime
 import dotenv
 import langfuse_utils
 import pandas as pd
+import utils_gateway
 from datasets import DatasetConfig, load_local_data
 from evaluators import create_refinement_quality_evaluator
 from themefinder import theme_refinement
@@ -50,11 +51,12 @@ async def evaluate_refinement(
 
     # Use provided LLM or create new one
     if llm is None:
+        base_url, api_key = utils_gateway.gateway_credentials()
         llm = OpenAILLM(
             model=os.getenv("AUTO_EVAL_4_1_SWEDEN_DEPLOYMENT"),
             request_kwargs={"temperature": 0},
-            base_url=os.getenv("LLM_GATEWAY_URL"),
-            api_key=os.getenv("CONSULT_EVAL_LITELLM_API_KEY"),
+            base_url=base_url,
+            api_key=api_key,
         )
 
     # Select judge LLM (falls back to task LLM if not provided)

--- a/evals/generate_synthetic.py
+++ b/evals/generate_synthetic.py
@@ -30,12 +30,13 @@ from synthetic.cli import (
     print_success,
     run_interactive_cli,
 )
+from synthetic.config import RESPONSE_GENERATION_MODEL
 from synthetic.generator import SyntheticDatasetGenerator
 
 # Optional Langfuse integration
 try:
     import langfuse_utils
-    from langfuse.openai import AsyncAzureOpenAI as _LangfuseAzureOpenAI
+    from langfuse.openai import AsyncOpenAI as _LangfuseOpenAI
 
     LANGFUSE_AVAILABLE = True
 except ImportError:
@@ -55,13 +56,10 @@ async def main() -> None:
 
     # Initialise LLM for response generation (gpt-5-nano with medium reasoning)
     # Medium reasoning ≈ o1 performance, 2x faster throughput than mini/low
-    _AzureClientClass = (
-        _LangfuseAzureOpenAI if LANGFUSE_AVAILABLE else openai.AsyncAzureOpenAI
-    )
-    client = _AzureClientClass(
-        azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
-        api_key=os.getenv("AZURE_OPENAI_API_KEY"),
-        api_version=os.getenv("OPENAI_API_VERSION", "2024-12-01-preview"),
+    _OpenAIClientClass = _LangfuseOpenAI if LANGFUSE_AVAILABLE else openai.AsyncOpenAI
+    client = _OpenAIClientClass(
+        base_url=os.getenv("LLM_GATEWAY_URL"),
+        api_key=os.getenv("CONSULT_EVAL_LITELLM_API_KEY"),
         timeout=600,  # 10 minute timeout to prevent indefinite hangs (reasoning can be slow)
     )
 
@@ -82,7 +80,7 @@ async def main() -> None:
     # Initialise generator
     generator = SyntheticDatasetGenerator(
         config=config,
-        llm=(client, "gpt-5-nano"),
+        llm=(client, RESPONSE_GENERATION_MODEL),
     )
 
     # Calculate total responses for summary

--- a/evals/generate_synthetic.py
+++ b/evals/generate_synthetic.py
@@ -24,6 +24,7 @@ import openai
 # Add parent to path for imports
 sys.path.insert(0, str(os.path.dirname(__file__)))
 
+import utils_gateway
 from synthetic.cli import (
     create_progress_bar,
     print_error,
@@ -57,9 +58,10 @@ async def main() -> None:
     # Initialise LLM for response generation (gpt-5-nano with medium reasoning)
     # Medium reasoning ≈ o1 performance, 2x faster throughput than mini/low
     _OpenAIClientClass = _LangfuseOpenAI if LANGFUSE_AVAILABLE else openai.AsyncOpenAI
+    base_url, api_key = utils_gateway.gateway_credentials()
     client = _OpenAIClientClass(
-        base_url=os.getenv("LLM_GATEWAY_URL"),
-        api_key=os.getenv("CONSULT_EVAL_LITELLM_API_KEY"),
+        base_url=base_url,
+        api_key=api_key,
         timeout=600,  # 10 minute timeout to prevent indefinite hangs (reasoning can be slow)
     )
 

--- a/evals/metrics.py
+++ b/evals/metrics.py
@@ -3,6 +3,7 @@ import os
 
 import numpy as np
 import pandas as pd
+import utils_gateway
 from sklearn import metrics, utils
 from sklearn.preprocessing import MultiLabelBinarizer
 from themefinder.llm import OpenAILLM
@@ -34,11 +35,12 @@ def calculate_generation_metrics(
             - Recall Average topic Representation: Mean representation score
     """
     if llm is None:
+        base_url, api_key = utils_gateway.gateway_credentials()
         llm = OpenAILLM(
             model=os.getenv("AUTO_EVAL_4_1_SWEDEN_DEPLOYMENT"),
             request_kwargs={"temperature": 0},
-            base_url=os.getenv("LLM_GATEWAY_URL"),
-            api_key=os.getenv("CONSULT_EVAL_LITELLM_API_KEY"),
+            base_url=base_url,
+            api_key=api_key,
         )
     precision_response = llm.invoke(
         generation_eval_prompt(

--- a/evals/synthetic/cli.py
+++ b/evals/synthetic/cli.py
@@ -198,10 +198,9 @@ async def run_interactive_cli() -> GenerationConfig:
     console.clear()
     console.print(BANNER)
 
-    client = openai.AsyncAzureOpenAI(
-        azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
-        api_key=os.getenv("AZURE_OPENAI_API_KEY"),
-        api_version=os.getenv("OPENAI_API_VERSION", "2024-12-01-preview"),
+    client = openai.AsyncOpenAI(
+        base_url=os.getenv("LLM_GATEWAY_URL"),
+        api_key=os.getenv("CONSULT_EVAL_LITELLM_API_KEY"),
         timeout=600,
     )
 
@@ -352,7 +351,7 @@ async def run_interactive_cli() -> GenerationConfig:
 
 
 async def _question_approval_workflow(
-    client: openai.AsyncAzureOpenAI,
+    client: openai.AsyncOpenAI,
     topic: str,
     n_questions: int,
 ) -> list[QuestionConfig]:
@@ -414,7 +413,7 @@ async def _question_approval_workflow(
 
 
 async def _context_field_workflow(
-    client: openai.AsyncAzureOpenAI,
+    client: openai.AsyncOpenAI,
     topic: str,
     questions: list[QuestionConfig],
 ) -> list[DemographicField]:
@@ -533,7 +532,7 @@ def _display_context_fields(fields: list[DemographicField]) -> None:
 
 
 async def _review_single_question(
-    client: openai.AsyncAzureOpenAI,
+    client: openai.AsyncOpenAI,
     gen_q: GeneratedQuestion,
     topic: str,
     question_num: int,

--- a/evals/synthetic/cli.py
+++ b/evals/synthetic/cli.py
@@ -1,9 +1,9 @@
 """Interactive CLI for synthetic consultation dataset generation."""
 
-import os
 from pathlib import Path
 
 import openai
+import utils_gateway
 from rich.box import DOUBLE, HEAVY, ROUNDED
 from rich.console import Console
 from rich.panel import Panel
@@ -198,9 +198,10 @@ async def run_interactive_cli() -> GenerationConfig:
     console.clear()
     console.print(BANNER)
 
+    base_url, api_key = utils_gateway.gateway_credentials()
     client = openai.AsyncOpenAI(
-        base_url=os.getenv("LLM_GATEWAY_URL"),
-        api_key=os.getenv("CONSULT_EVAL_LITELLM_API_KEY"),
+        base_url=base_url,
+        api_key=api_key,
         timeout=600,
     )
 

--- a/evals/synthetic/config.py
+++ b/evals/synthetic/config.py
@@ -5,6 +5,13 @@ from enum import Enum
 from pathlib import Path
 from typing import Optional
 
+# Models stay hardcoded here rather than dynamically discovered (unlike
+# benchmark.py) — this tool always uses one fixed model per role, so there's
+# nothing to select. Centralised as named constants instead of duplicating
+# the literal strings across every generator module.
+DRAFTING_MODEL = "gpt-5-mini-sweden"  # question/context/theme generation
+RESPONSE_GENERATION_MODEL = "gpt-5-nano-sweden"  # bulk respondent response generation
+
 
 class NoiseLevel(Enum):
     """Noise injection intensity levels."""

--- a/evals/synthetic/generator.py
+++ b/evals/synthetic/generator.py
@@ -40,14 +40,14 @@ class SyntheticDatasetGenerator:
     def __init__(
         self,
         config: GenerationConfig,
-        llm: tuple[openai.AsyncAzureOpenAI, str],
+        llm: tuple[openai.AsyncOpenAI, str],
         seed: int = 42,
     ) -> None:
         """Initialise generator with configuration.
 
         Args:
             config: Generation configuration.
-            llm: Tuple of (AsyncAzureOpenAI client, deployment name) for response generation.
+            llm: Tuple of (AsyncOpenAI client, deployment name) for response generation.
             seed: Random seed for reproducibility.
         """
         self.config = config

--- a/evals/synthetic/llm_generators/context_generator.py
+++ b/evals/synthetic/llm_generators/context_generator.py
@@ -11,7 +11,7 @@ import logging
 import openai
 from pydantic import BaseModel, Field, ValidationError
 
-from synthetic.config import DemographicField, QuestionConfig
+from synthetic.config import DRAFTING_MODEL, DemographicField, QuestionConfig
 
 logger = logging.getLogger(__name__)
 
@@ -94,7 +94,7 @@ for understanding perspectives on this policy."""
 
 
 async def generate_context_fields(
-    client: openai.AsyncAzureOpenAI,
+    client: openai.AsyncOpenAI,
     topic: str,
     questions: list[QuestionConfig],
     n_fields: int = 4,
@@ -143,7 +143,7 @@ Avoid generic demographics (age, region, etc.) - those are handled separately.""
             result = (
                 (
                     await client.beta.chat.completions.parse(
-                        model="gpt-5-mini",
+                        model=DRAFTING_MODEL,
                         messages=messages,
                         response_format=ContextFieldSet,
                         reasoning_effort="medium",
@@ -205,7 +205,7 @@ Avoid generic demographics (age, region, etc.) - those are handled separately.""
 
 
 async def regenerate_context_fields(
-    client: openai.AsyncAzureOpenAI,
+    client: openai.AsyncOpenAI,
     topic: str,
     questions: list[QuestionConfig],
     feedback: str,
@@ -214,7 +214,7 @@ async def regenerate_context_fields(
     """Regenerate context fields based on user feedback.
 
     Args:
-        client: Azure OpenAI client.
+        client: OpenAI client (gateway-routed).
         topic: Consultation topic.
         questions: List of consultation questions.
         feedback: User's feedback on what to change.
@@ -255,7 +255,7 @@ Focus on characteristics directly relevant to this policy."""
             result = (
                 (
                     await client.beta.chat.completions.parse(
-                        model="gpt-5-mini",
+                        model=DRAFTING_MODEL,
                         messages=messages,
                         response_format=ContextFieldSet,
                         reasoning_effort="medium",

--- a/evals/synthetic/llm_generators/question_generator.py
+++ b/evals/synthetic/llm_generators/question_generator.py
@@ -7,6 +7,8 @@ principles and the Gunning Principles for fair consultation.
 import openai
 from pydantic import BaseModel, Field
 
+from synthetic.config import DRAFTING_MODEL
+
 
 class GeneratedQuestion(BaseModel):
     """A single generated consultation question."""
@@ -88,7 +90,7 @@ Generate questions that would realistically appear in a UK government consultati
 
 
 async def generate_questions(
-    client: openai.AsyncAzureOpenAI,
+    client: openai.AsyncOpenAI,
     topic: str,
     n_questions: int,
     existing_questions: list[str] | None = None,
@@ -152,7 +154,7 @@ For each question, provide:
     result = (
         (
             await client.beta.chat.completions.parse(
-                model="gpt-5-mini",
+                model=DRAFTING_MODEL,
                 messages=messages,
                 response_format=QuestionSet,
                 reasoning_effort="high",
@@ -165,7 +167,7 @@ For each question, provide:
 
 
 async def regenerate_single_question(
-    client: openai.AsyncAzureOpenAI,
+    client: openai.AsyncOpenAI,
     topic: str,
     rejected_question: str,
     feedback: str,
@@ -174,7 +176,7 @@ async def regenerate_single_question(
     """Regenerate a single question based on user feedback.
 
     Args:
-        client: Azure OpenAI client.
+        client: OpenAI client (gateway-routed).
         topic: The policy topic for the consultation.
         rejected_question: The question that was rejected.
         feedback: User's feedback on why it was rejected.
@@ -217,7 +219,7 @@ Generate ONE new question that:
     return (
         (
             await client.beta.chat.completions.parse(
-                model="gpt-5-mini",
+                model=DRAFTING_MODEL,
                 messages=messages,
                 response_format=GeneratedQuestion,
                 reasoning_effort="high",
@@ -237,14 +239,14 @@ class DatasetName(BaseModel):
 
 
 async def generate_dataset_name(
-    client: openai.AsyncAzureOpenAI,
+    client: openai.AsyncOpenAI,
     topic: str,
     questions: list[str],
 ) -> str:
     """Generate a short, descriptive dataset name from the consultation topic and questions.
 
     Args:
-        client: Azure OpenAI client.
+        client: OpenAI client (gateway-routed).
         topic: The consultation topic (can be long document).
         questions: List of approved question texts.
 
@@ -285,7 +287,7 @@ Generate ONE dataset name."""
     result = (
         (
             await client.beta.chat.completions.parse(
-                model="gpt-5-mini",
+                model=DRAFTING_MODEL,
                 messages=messages,
                 response_format=DatasetName,
                 reasoning_effort="high",

--- a/evals/synthetic/llm_generators/response_generator.py
+++ b/evals/synthetic/llm_generators/response_generator.py
@@ -86,7 +86,7 @@ Generate authentic-sounding responses. Vary sentence structure and vocabulary.""
 
 
 async def generate_respondent_survey(
-    llm: tuple[openai.AsyncAzureOpenAI, str],
+    llm: tuple[openai.AsyncOpenAI, str],
     respondent: RespondentSpec,
     questions: list[QuestionConfig],
     themes_by_question: dict[int, list[dict]],
@@ -99,7 +99,7 @@ async def generate_respondent_survey(
     to maintain consistency in the respondent's viewpoint.
 
     Args:
-        llm: Tuple of (AsyncAzureOpenAI client, deployment name).
+        llm: Tuple of (AsyncOpenAI client, deployment name).
         respondent: Respondent specification with persona and base disposition.
         questions: List of question configurations in order.
         themes_by_question: Dict mapping question number to themes list.
@@ -232,7 +232,7 @@ async def generate_respondent_survey(
 
 
 async def generate_respondent_batch(
-    llm: tuple[openai.AsyncAzureOpenAI, str],
+    llm: tuple[openai.AsyncOpenAI, str],
     respondents: list[RespondentSpec],
     questions: list[QuestionConfig],
     themes_by_question: dict[int, list[dict]],
@@ -245,7 +245,7 @@ async def generate_respondent_batch(
     but multiple respondents are processed in parallel.
 
     Args:
-        llm: Tuple of (AsyncAzureOpenAI client, deployment name).
+        llm: Tuple of (AsyncOpenAI client, deployment name).
         respondents: List of respondent specifications.
         questions: List of question configurations in order.
         themes_by_question: Dict mapping question number to themes list.

--- a/evals/synthetic/llm_generators/theme_generator.py
+++ b/evals/synthetic/llm_generators/theme_generator.py
@@ -11,7 +11,7 @@ from collections.abc import Callable
 import openai
 from pydantic import BaseModel, Field, ValidationError
 
-from synthetic.config import DemographicField
+from synthetic.config import DRAFTING_MODEL, DemographicField
 
 logger = logging.getLogger(__name__)
 
@@ -133,7 +133,7 @@ def _generate_topic_ids(n: int) -> list[str]:
 
 
 async def generate_themes(
-    client: openai.AsyncAzureOpenAI,
+    client: openai.AsyncOpenAI,
     topic: str,
     question: str,
     demographic_fields: list[DemographicField],
@@ -191,7 +191,7 @@ async def generate_themes(
 
 
 async def _fan_out_theme_generation(
-    client: openai.AsyncAzureOpenAI,
+    client: openai.AsyncOpenAI,
     topic: str,
     question: str,
     demographic_fields: list[DemographicField],
@@ -249,7 +249,7 @@ Use sequential IDs: A, B, C, ... Z, AA, AB, ... for themes."""
                 result = (
                     (
                         await client.beta.chat.completions.parse(
-                            model="gpt-5-mini",
+                            model=DRAFTING_MODEL,
                             messages=messages,
                             response_format=ThemeSet,
                             reasoning_effort="medium",
@@ -313,7 +313,7 @@ Use sequential IDs: A, B, C, ... Z, AA, AB, ... for themes."""
 
 
 async def _consolidate_themes(
-    client: openai.AsyncAzureOpenAI,
+    client: openai.AsyncOpenAI,
     raw_themes: list[dict],
     topic: str,
     question: str,
@@ -365,7 +365,7 @@ Be CONSERVATIVE - when in doubt, keep themes separate. Diversity is valuable."""
             result = (
                 (
                     await client.beta.chat.completions.parse(
-                        model="gpt-5-mini",
+                        model=DRAFTING_MODEL,
                         messages=messages,
                         response_format=ThemeSet,
                         reasoning_effort="low",

--- a/evals/tests/conftest.py
+++ b/evals/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))

--- a/evals/tests/conftest.py
+++ b/evals/tests/conftest.py
@@ -2,3 +2,17 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import utils_gateway  # noqa: E402
+
+
+def make_gateway_model(
+    name: str,
+    family: str | None = "gpt",
+    health: str = "healthy",
+    supports_reasoning: bool = False,
+) -> utils_gateway.GatewayModel:
+    """Shared GatewayModel test fixture builder for test_utils_gateway.py / test_benchmark.py."""
+    return utils_gateway.GatewayModel(
+        name=name, family=family, health=health, supports_reasoning=supports_reasoning
+    )

--- a/evals/tests/test_benchmark.py
+++ b/evals/tests/test_benchmark.py
@@ -66,7 +66,11 @@ class TestApplyQuickPreset:
 
     def test_overrides_other_selectors_when_quick(self):
         args = _args(
-            models=["something"], family=["gpt"], quick=True, dataset="housing_S", runs=5
+            models=["something"],
+            family=["gpt"],
+            quick=True,
+            dataset="housing_S",
+            runs=5,
         )
         benchmark._apply_quick_preset(args)
         assert args.dataset == "gambling_XS"
@@ -97,7 +101,9 @@ class TestResolveSelectedModels:
 
     def test_models_selector_returns_found_and_missing(self):
         args = _args(models=["gpt-4o-uk", "typo-model"])
-        selected, missing, unhealthy = benchmark._resolve_selected_models(args, self.MODELS)
+        selected, missing, unhealthy = benchmark._resolve_selected_models(
+            args, self.MODELS
+        )
         assert [m.name for m in selected] == ["gpt-4o-uk"]
         assert missing == ["typo-model"]
         assert unhealthy == []
@@ -106,21 +112,27 @@ class TestResolveSelectedModels:
         # --models is explicit-by-name: unhealthy matches are still selected
         # (main() warns using `unhealthy`, doesn't silently drop them)
         args = _args(models=["claude-haiku"])
-        selected, missing, unhealthy = benchmark._resolve_selected_models(args, self.MODELS)
+        selected, missing, unhealthy = benchmark._resolve_selected_models(
+            args, self.MODELS
+        )
         assert [m.name for m in selected] == ["claude-haiku"]
         assert missing == []
         assert [m.name for m in unhealthy] == ["claude-haiku"]
 
     def test_family_selector_excludes_unhealthy(self):
         args = _args(family=["claude"])
-        selected, missing, unhealthy = benchmark._resolve_selected_models(args, self.MODELS)
+        selected, missing, unhealthy = benchmark._resolve_selected_models(
+            args, self.MODELS
+        )
         assert selected == []  # claude-haiku is unhealthy, dropped
         assert missing == []
         assert unhealthy == []
 
     def test_all_selector_excludes_unhealthy_and_ignores_family(self):
         args = _args(all_=True)
-        selected, missing, unhealthy = benchmark._resolve_selected_models(args, self.MODELS)
+        selected, missing, unhealthy = benchmark._resolve_selected_models(
+            args, self.MODELS
+        )
         assert {m.name for m in selected} == {"gpt-4o-uk", "gemini-flash"}
         assert missing == []
         assert unhealthy == []

--- a/evals/tests/test_benchmark.py
+++ b/evals/tests/test_benchmark.py
@@ -92,47 +92,45 @@ class TestValidateSelectorArgs:
         assert benchmark._validate_selector_args(args) is not None
 
 
-class TestResolveSelectedModels:
+class TestSelectNamedModels:
     MODELS = [
         make_gateway_model(name="gpt-4o-uk", family="gpt"),
         make_gateway_model(name="claude-haiku", family="claude", health="unhealthy"),
         make_gateway_model(name="gemini-flash", family="gemini"),
     ]
 
-    def test_models_selector_returns_found_and_missing(self):
-        args = _args(models=["gpt-4o-uk", "typo-model"])
-        selected, missing, unhealthy = benchmark._resolve_selected_models(
-            args, self.MODELS
+    def test_returns_found_and_missing(self):
+        selected, missing, unhealthy = benchmark._select_named_models(
+            self.MODELS, ["gpt-4o-uk", "typo-model"]
         )
         assert [m.name for m in selected] == ["gpt-4o-uk"]
         assert missing == ["typo-model"]
         assert unhealthy == []
 
-    def test_models_selector_reports_unhealthy_matches(self):
+    def test_reports_unhealthy_matches_but_still_selects_them(self):
         # --models is explicit-by-name: unhealthy matches are still selected
         # (main() warns using `unhealthy`, doesn't silently drop them)
-        args = _args(models=["claude-haiku"])
-        selected, missing, unhealthy = benchmark._resolve_selected_models(
-            args, self.MODELS
+        selected, missing, unhealthy = benchmark._select_named_models(
+            self.MODELS, ["claude-haiku"]
         )
         assert [m.name for m in selected] == ["claude-haiku"]
         assert missing == []
         assert [m.name for m in unhealthy] == ["claude-haiku"]
 
-    def test_family_selector_excludes_unhealthy(self):
-        args = _args(family=["claude"])
-        selected, missing, unhealthy = benchmark._resolve_selected_models(
-            args, self.MODELS
-        )
-        assert selected == []  # claude-haiku is unhealthy, dropped
-        assert missing == []
-        assert unhealthy == []
 
-    def test_all_selector_excludes_unhealthy_and_ignores_family(self):
-        args = _args(all_=True)
-        selected, missing, unhealthy = benchmark._resolve_selected_models(
-            args, self.MODELS
-        )
+class TestSelectHealthyModels:
+    MODELS = [
+        make_gateway_model(name="gpt-4o-uk", family="gpt"),
+        make_gateway_model(name="claude-haiku", family="claude", health="unhealthy"),
+        make_gateway_model(name="gemini-flash", family="gemini"),
+    ]
+
+    def test_family_excludes_unhealthy(self):
+        selected, excluded = benchmark._select_healthy_models(self.MODELS, ["claude"])
+        assert selected == []  # claude-haiku is unhealthy, dropped
+        assert [m.name for m in excluded] == ["claude-haiku"]
+
+    def test_no_family_excludes_unhealthy_and_returns_the_rest(self):
+        selected, excluded = benchmark._select_healthy_models(self.MODELS, None)
         assert {m.name for m in selected} == {"gpt-4o-uk", "gemini-flash"}
-        assert missing == []
-        assert unhealthy == []
+        assert [m.name for m in excluded] == ["claude-haiku"]

--- a/evals/tests/test_benchmark.py
+++ b/evals/tests/test_benchmark.py
@@ -1,0 +1,126 @@
+import argparse
+
+import benchmark
+from conftest import make_gateway_model
+
+
+def _args(models=None, family=None, all_=False, **extra):
+    return argparse.Namespace(models=models, family=family, all=all_, **extra)
+
+
+class TestModelConfigTag:
+    def test_plain_name_when_no_reasoning_effort(self):
+        config = benchmark.ModelConfig(name="gpt-4o-uk")
+        assert config.tag == "gpt-4o-uk"
+
+    def test_appends_reasoning_effort(self):
+        config = benchmark.ModelConfig(name="gpt-5-mini-sweden", reasoning_effort="low")
+        assert config.tag == "gpt-5-mini-sweden_low"
+
+
+class TestModelConfigCreateLlm:
+    def _set_gateway_env(self, monkeypatch):
+        monkeypatch.setenv("LLM_GATEWAY_URL", "https://gateway.example.invalid")
+        monkeypatch.setenv("CONSULT_EVAL_LITELLM_API_KEY", "test-key")
+
+    def test_sets_temperature_when_no_reasoning_effort(self, monkeypatch):
+        self._set_gateway_env(monkeypatch)
+        config = benchmark.ModelConfig(name="gpt-4o-uk", temperature=0.2)
+        llm = config.create_llm()
+        assert llm.model == "gpt-4o-uk"
+        assert llm.request_kwargs == {"temperature": 0.2}
+
+    def test_omits_temperature_when_reasoning_effort_set(self, monkeypatch):
+        self._set_gateway_env(monkeypatch)
+        config = benchmark.ModelConfig(name="gpt-5-mini-sweden", reasoning_effort="low")
+        llm = config.create_llm()
+        assert llm.model == "gpt-5-mini-sweden"
+        assert llm.request_kwargs == {}
+
+
+class TestToModelConfigs:
+    def test_non_reasoning_model_ignores_effort_levels(self):
+        gm = make_gateway_model(name="gpt-4o-uk", supports_reasoning=False)
+        configs = benchmark._to_model_configs(gm, ["low", "medium", "high"])
+        assert len(configs) == 1
+        assert configs[0].name == "gpt-4o-uk"
+        assert configs[0].reasoning_effort is None
+
+    def test_reasoning_model_expands_per_effort_level(self):
+        gm = make_gateway_model(name="gpt-5-mini-sweden", supports_reasoning=True)
+        configs = benchmark._to_model_configs(gm, ["low", "medium", "high"])
+        assert [c.tag for c in configs] == [
+            "gpt-5-mini-sweden_low",
+            "gpt-5-mini-sweden_medium",
+            "gpt-5-mini-sweden_high",
+        ]
+
+
+class TestApplyQuickPreset:
+    def test_noop_when_not_quick(self):
+        args = _args(all_=True, quick=False, dataset="housing_S", runs=5)
+        benchmark._apply_quick_preset(args)
+        assert args.dataset == "housing_S"
+        assert args.runs == 5
+        assert args.all is True
+
+    def test_overrides_other_selectors_when_quick(self):
+        args = _args(
+            models=["something"], family=["gpt"], quick=True, dataset="housing_S", runs=5
+        )
+        benchmark._apply_quick_preset(args)
+        assert args.dataset == "gambling_XS"
+        assert args.runs == 1
+        assert args.models == ["gpt-4.1-sweden-2025-03"]
+        assert args.family is None
+        assert args.all is False
+
+
+class TestValidateSelectorArgs:
+    def test_exactly_one_selector_is_valid(self):
+        assert benchmark._validate_selector_args(_args(models=["gpt-4o-uk"])) is None
+
+    def test_no_selector_is_invalid(self):
+        assert benchmark._validate_selector_args(_args()) is not None
+
+    def test_multiple_selectors_is_invalid(self):
+        args = _args(models=["gpt-4o-uk"], family=["gpt"])
+        assert benchmark._validate_selector_args(args) is not None
+
+
+class TestResolveSelectedModels:
+    MODELS = [
+        make_gateway_model(name="gpt-4o-uk", family="gpt"),
+        make_gateway_model(name="claude-haiku", family="claude", health="unhealthy"),
+        make_gateway_model(name="gemini-flash", family="gemini"),
+    ]
+
+    def test_models_selector_returns_found_and_missing(self):
+        args = _args(models=["gpt-4o-uk", "typo-model"])
+        selected, missing, unhealthy = benchmark._resolve_selected_models(args, self.MODELS)
+        assert [m.name for m in selected] == ["gpt-4o-uk"]
+        assert missing == ["typo-model"]
+        assert unhealthy == []
+
+    def test_models_selector_reports_unhealthy_matches(self):
+        # --models is explicit-by-name: unhealthy matches are still selected
+        # (main() warns using `unhealthy`, doesn't silently drop them)
+        args = _args(models=["claude-haiku"])
+        selected, missing, unhealthy = benchmark._resolve_selected_models(args, self.MODELS)
+        assert [m.name for m in selected] == ["claude-haiku"]
+        assert missing == []
+        assert [m.name for m in unhealthy] == ["claude-haiku"]
+
+    def test_family_selector_excludes_unhealthy(self):
+        args = _args(family=["claude"])
+        selected, missing, unhealthy = benchmark._resolve_selected_models(args, self.MODELS)
+        assert selected == []  # claude-haiku is unhealthy, dropped
+        assert missing == []
+        assert unhealthy == []
+
+    def test_all_selector_excludes_unhealthy_and_ignores_family(self):
+        args = _args(all_=True)
+        selected, missing, unhealthy = benchmark._resolve_selected_models(args, self.MODELS)
+        assert {m.name for m in selected} == {"gpt-4o-uk", "gemini-flash"}
+        assert missing == []
+        assert unhealthy == []

--- a/evals/tests/test_utils_gateway.py
+++ b/evals/tests/test_utils_gateway.py
@@ -80,8 +80,61 @@ class TestDeriveFamily:
         assert utils_gateway.derive_family(name) == expected
 
 
+class TestFilterByFamily:
+    MODELS = [
+        utils_gateway.GatewayModel(name="gpt-4o", family="gpt", health="healthy"),
+        utils_gateway.GatewayModel(name="claude-haiku", family="claude", health="healthy"),
+        utils_gateway.GatewayModel(name="gemini-flash", family="gemini", health="healthy"),
+        utils_gateway.GatewayModel(name="bedrock-qwen3", family=None, health="healthy"),
+    ]
+
+    def test_single_family(self):
+        result = utils_gateway.filter_by_family(self.MODELS, ["claude"])
+        assert [m.name for m in result] == ["claude-haiku"]
+
+    def test_multiple_families(self):
+        result = utils_gateway.filter_by_family(self.MODELS, ["gemini", "claude"])
+        assert {m.name for m in result} == {"gemini-flash", "claude-haiku"}
+
+    def test_no_match_returns_empty(self):
+        assert utils_gateway.filter_by_family(self.MODELS, ["locai"]) == []
+
+
+class TestSelectByName:
+    MODELS = [
+        utils_gateway.GatewayModel(name="gpt-4o", family="gpt", health="healthy"),
+        utils_gateway.GatewayModel(name="claude-haiku", family="claude", health="unhealthy"),
+    ]
+
+    def test_all_found(self):
+        found, missing = utils_gateway.select_by_name(self.MODELS, ["gpt-4o", "claude-haiku"])
+        assert {m.name for m in found} == {"gpt-4o", "claude-haiku"}
+        assert missing == []
+
+    def test_some_missing(self):
+        found, missing = utils_gateway.select_by_name(self.MODELS, ["gpt-4o", "typo-model"])
+        assert [m.name for m in found] == ["gpt-4o"]
+        assert missing == ["typo-model"]
+
+    def test_found_model_keeps_its_health_status(self):
+        found, _ = utils_gateway.select_by_name(self.MODELS, ["claude-haiku"])
+        assert found[0].health == "unhealthy"
+
+
+class TestExcludeUnhealthy:
+    MODELS = [
+        utils_gateway.GatewayModel(name="gpt-4o", family="gpt", health="healthy"),
+        utils_gateway.GatewayModel(name="claude-haiku", family="claude", health="unhealthy"),
+        utils_gateway.GatewayModel(name="mystery-model", family=None, health="unknown"),
+    ]
+
+    def test_drops_unhealthy_keeps_healthy_and_unknown(self):
+        result = utils_gateway.exclude_unhealthy(self.MODELS)
+        assert {m.name for m in result} == {"gpt-4o", "mystery-model"}
+
+
 class TestDiscoverChatModels:
-    async def test_combines_and_filters(self, monkeypatch):
+    async def test_combines_and_resolves_unfiltered(self, monkeypatch):
         model_group_items = [
             {"model_group": "gpt-4o", "mode": "chat"},
             {"model_group": "claude-haiku", "mode": "chat"},
@@ -112,9 +165,10 @@ class TestDiscoverChatModels:
         result = await utils_gateway.discover_chat_models()
 
         by_name = {m.name: m for m in result}
-        assert set(by_name) == {"gpt-4o", "gemini-flash", "mystery-model"}
-        assert "claude-haiku" not in by_name  # unhealthy + fresh -> excluded
+        # unfiltered: non-chat excluded, but unhealthy/stale/unknown models all present
+        assert set(by_name) == {"gpt-4o", "claude-haiku", "gemini-flash", "mystery-model"}
         assert by_name["gpt-4o"].health == "healthy"
+        assert by_name["claude-haiku"].health == "unhealthy"
         assert by_name["gemini-flash"].health == "unknown"  # stale, not trusted
         assert by_name["mystery-model"].health == "unknown"  # no data at all
         assert by_name["gpt-4o"].family == "gpt"

--- a/evals/tests/test_utils_gateway.py
+++ b/evals/tests/test_utils_gateway.py
@@ -138,16 +138,17 @@ class TestSelectByName:
         assert found[0].health == "unhealthy"
 
 
-class TestExcludeUnhealthy:
+class TestSplitUnhealthy:
     MODELS = [
         make_gateway_model(name="gpt-4o", family="gpt"),
         make_gateway_model(name="claude-haiku", family="claude", health="unhealthy"),
         make_gateway_model(name="mystery-model", family=None, health="unknown"),
     ]
 
-    def test_drops_unhealthy_keeps_healthy_and_unknown(self):
-        result = utils_gateway.exclude_unhealthy(self.MODELS)
-        assert {m.name for m in result} == {"gpt-4o", "mystery-model"}
+    def test_keeps_healthy_and_unknown_splits_out_unhealthy(self):
+        kept, unhealthy = utils_gateway.split_unhealthy(self.MODELS)
+        assert {m.name for m in kept} == {"gpt-4o", "mystery-model"}
+        assert [m.name for m in unhealthy] == ["claude-haiku"]
 
 
 class TestDiscoverChatModels:

--- a/evals/tests/test_utils_gateway.py
+++ b/evals/tests/test_utils_gateway.py
@@ -10,7 +10,11 @@ def _health(model_name, status, hours_ago, check_id=None, now=None):
     now = now or datetime.now(timezone.utc)
     checked_at = (now - timedelta(hours=hours_ago)).isoformat()
     check_id = check_id or f"{model_name}-{hours_ago}-{status}"
-    return check_id, {"model_name": model_name, "status": status, "checked_at": checked_at}
+    return check_id, {
+        "model_name": model_name,
+        "status": status,
+        "checked_at": checked_at,
+    }
 
 
 class TestFilterChatModels:
@@ -45,8 +49,12 @@ class TestLatestHealthByModel:
     def test_most_recent_check_wins(self):
         checks = dict(
             [
-                _health("gpt-4o", "healthy", hours_ago=48, check_id="old", now=self.NOW),
-                _health("gpt-4o", "unhealthy", hours_ago=1, check_id="new", now=self.NOW),
+                _health(
+                    "gpt-4o", "healthy", hours_ago=48, check_id="old", now=self.NOW
+                ),
+                _health(
+                    "gpt-4o", "unhealthy", hours_ago=1, check_id="new", now=self.NOW
+                ),
             ]
         )
         assert utils_gateway.latest_health_by_model(checks, now=self.NOW) == {
@@ -56,8 +64,12 @@ class TestLatestHealthByModel:
     def test_most_recent_check_wins_regardless_of_dict_order(self):
         checks = dict(
             [
-                _health("gpt-4o", "unhealthy", hours_ago=1, check_id="new", now=self.NOW),
-                _health("gpt-4o", "healthy", hours_ago=48, check_id="old", now=self.NOW),
+                _health(
+                    "gpt-4o", "unhealthy", hours_ago=1, check_id="new", now=self.NOW
+                ),
+                _health(
+                    "gpt-4o", "healthy", hours_ago=48, check_id="old", now=self.NOW
+                ),
             ]
         )
         assert utils_gateway.latest_health_by_model(checks, now=self.NOW) == {
@@ -108,12 +120,16 @@ class TestSelectByName:
     ]
 
     def test_all_found(self):
-        found, missing = utils_gateway.select_by_name(self.MODELS, ["gpt-4o", "claude-haiku"])
+        found, missing = utils_gateway.select_by_name(
+            self.MODELS, ["gpt-4o", "claude-haiku"]
+        )
         assert {m.name for m in found} == {"gpt-4o", "claude-haiku"}
         assert missing == []
 
     def test_some_missing(self):
-        found, missing = utils_gateway.select_by_name(self.MODELS, ["gpt-4o", "typo-model"])
+        found, missing = utils_gateway.select_by_name(
+            self.MODELS, ["gpt-4o", "typo-model"]
+        )
         assert [m.name for m in found] == ["gpt-4o"]
         assert missing == ["typo-model"]
 
@@ -138,9 +154,17 @@ class TestDiscoverChatModels:
     async def test_combines_and_resolves_unfiltered(self, monkeypatch):
         model_group_items = [
             {"model_group": "gpt-4o", "mode": "chat", "supports_reasoning": False},
-            {"model_group": "claude-haiku", "mode": "chat", "supports_reasoning": False},
+            {
+                "model_group": "claude-haiku",
+                "mode": "chat",
+                "supports_reasoning": False,
+            },
             {"model_group": "gemini-flash", "mode": "chat", "supports_reasoning": True},
-            {"model_group": "mystery-model", "mode": "chat", "supports_reasoning": False},
+            {
+                "model_group": "mystery-model",
+                "mode": "chat",
+                "supports_reasoning": False,
+            },
             {"model_group": "text-embedding-3", "mode": "embedding"},
         ]
         health_checks = dict(
@@ -158,7 +182,9 @@ class TestDiscoverChatModels:
         async def fake_health_latest(client):
             return health_checks
 
-        monkeypatch.setattr(utils_gateway, "fetch_model_group_info", fake_model_group_info)
+        monkeypatch.setattr(
+            utils_gateway, "fetch_model_group_info", fake_model_group_info
+        )
         monkeypatch.setattr(utils_gateway, "fetch_health_latest", fake_health_latest)
         monkeypatch.setenv("LLM_GATEWAY_URL", "https://gateway.example.invalid")
         monkeypatch.setenv("CONSULT_EVAL_LITELLM_API_KEY", "test-key")
@@ -167,7 +193,12 @@ class TestDiscoverChatModels:
 
         by_name = {m.name: m for m in result}
         # unfiltered: non-chat excluded, but unhealthy/stale/unknown models all present
-        assert set(by_name) == {"gpt-4o", "claude-haiku", "gemini-flash", "mystery-model"}
+        assert set(by_name) == {
+            "gpt-4o",
+            "claude-haiku",
+            "gemini-flash",
+            "mystery-model",
+        }
         assert by_name["gpt-4o"].health == "healthy"
         assert by_name["claude-haiku"].health == "unhealthy"
         assert by_name["gemini-flash"].health == "unknown"  # stale, not trusted

--- a/evals/tests/test_utils_gateway.py
+++ b/evals/tests/test_utils_gateway.py
@@ -1,0 +1,122 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+import utils_gateway
+
+
+def _health(model_name, status, hours_ago, check_id=None, now=None):
+    now = now or datetime.now(timezone.utc)
+    checked_at = (now - timedelta(hours=hours_ago)).isoformat()
+    check_id = check_id or f"{model_name}-{hours_ago}-{status}"
+    return check_id, {"model_name": model_name, "status": status, "checked_at": checked_at}
+
+
+class TestFilterChatModels:
+    def test_keeps_only_chat_mode(self):
+        items = [
+            {"model_group": "gpt-4o", "mode": "chat"},
+            {"model_group": "dall-e-3", "mode": "image_generation"},
+            {"model_group": "text-embedding-3", "mode": "embedding"},
+        ]
+        assert utils_gateway.filter_chat_models(items) == ["gpt-4o"]
+
+
+class TestLatestHealthByModel:
+    NOW = datetime(2026, 8, 5, 12, 0, tzinfo=timezone.utc)
+
+    def test_healthy_fresh_included(self):
+        checks = dict([_health("gpt-4o", "healthy", hours_ago=1, now=self.NOW)])
+        assert utils_gateway.latest_health_by_model(checks, now=self.NOW) == {
+            "gpt-4o": "healthy"
+        }
+
+    def test_unhealthy_fresh_included(self):
+        checks = dict([_health("gpt-4o", "unhealthy", hours_ago=1, now=self.NOW)])
+        assert utils_gateway.latest_health_by_model(checks, now=self.NOW) == {
+            "gpt-4o": "unhealthy"
+        }
+
+    def test_stale_check_dropped(self):
+        checks = dict([_health("gpt-4o", "unhealthy", hours_ago=200, now=self.NOW)])
+        assert utils_gateway.latest_health_by_model(checks, now=self.NOW) == {}
+
+    def test_most_recent_check_wins(self):
+        checks = dict(
+            [
+                _health("gpt-4o", "healthy", hours_ago=48, check_id="old", now=self.NOW),
+                _health("gpt-4o", "unhealthy", hours_ago=1, check_id="new", now=self.NOW),
+            ]
+        )
+        assert utils_gateway.latest_health_by_model(checks, now=self.NOW) == {
+            "gpt-4o": "unhealthy"
+        }
+
+    def test_most_recent_check_wins_regardless_of_dict_order(self):
+        checks = dict(
+            [
+                _health("gpt-4o", "unhealthy", hours_ago=1, check_id="new", now=self.NOW),
+                _health("gpt-4o", "healthy", hours_ago=48, check_id="old", now=self.NOW),
+            ]
+        )
+        assert utils_gateway.latest_health_by_model(checks, now=self.NOW) == {
+            "gpt-4o": "unhealthy"
+        }
+
+
+class TestDeriveFamily:
+    @pytest.mark.parametrize(
+        "name,expected",
+        [
+            ("gpt-4.1-sweden", "gpt"),
+            ("o3-mini", "gpt"),
+            ("claude-haiku-4.5", "claude"),
+            ("gemini-2.5-flash", "gemini"),
+            ("locailabs/locai-l1-large-2011", "locai"),
+            ("mistral-large", None),
+        ],
+    )
+    def test_family_bucket(self, name, expected):
+        assert utils_gateway.derive_family(name) == expected
+
+
+class TestDiscoverChatModels:
+    async def test_combines_and_filters(self, monkeypatch):
+        model_group_items = [
+            {"model_group": "gpt-4o", "mode": "chat"},
+            {"model_group": "claude-haiku", "mode": "chat"},
+            {"model_group": "gemini-flash", "mode": "chat"},
+            {"model_group": "mystery-model", "mode": "chat"},
+            {"model_group": "text-embedding-3", "mode": "embedding"},
+        ]
+        health_checks = dict(
+            [
+                _health("gpt-4o", "healthy", hours_ago=1),
+                _health("claude-haiku", "unhealthy", hours_ago=1),
+                _health("gemini-flash", "unhealthy", hours_ago=200),  # stale
+                # mystery-model: no health data at all
+            ]
+        )
+
+        async def fake_model_group_info(client):
+            return model_group_items
+
+        async def fake_health_latest(client):
+            return health_checks
+
+        monkeypatch.setattr(utils_gateway, "fetch_model_group_info", fake_model_group_info)
+        monkeypatch.setattr(utils_gateway, "fetch_health_latest", fake_health_latest)
+        monkeypatch.setenv("LLM_GATEWAY_URL", "https://gateway.example.invalid")
+        monkeypatch.setenv("CONSULT_EVAL_LITELLM_API_KEY", "test-key")
+
+        result = await utils_gateway.discover_chat_models()
+
+        by_name = {m.name: m for m in result}
+        assert set(by_name) == {"gpt-4o", "gemini-flash", "mystery-model"}
+        assert "claude-haiku" not in by_name  # unhealthy + fresh -> excluded
+        assert by_name["gpt-4o"].health == "healthy"
+        assert by_name["gemini-flash"].health == "unknown"  # stale, not trusted
+        assert by_name["mystery-model"].health == "unknown"  # no data at all
+        assert by_name["gpt-4o"].family == "gpt"
+        assert by_name["gemini-flash"].family == "gemini"
+        assert by_name["mystery-model"].family is None

--- a/evals/tests/test_utils_gateway.py
+++ b/evals/tests/test_utils_gateway.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta, timezone
 import pytest
 
 import utils_gateway
+from conftest import make_gateway_model
 
 
 def _health(model_name, status, hours_ago, check_id=None, now=None):
@@ -15,11 +16,11 @@ def _health(model_name, status, hours_ago, check_id=None, now=None):
 class TestFilterChatModels:
     def test_keeps_only_chat_mode(self):
         items = [
-            {"model_group": "gpt-4o", "mode": "chat"},
+            {"model_group": "gpt-4o", "mode": "chat", "supports_reasoning": False},
             {"model_group": "dall-e-3", "mode": "image_generation"},
             {"model_group": "text-embedding-3", "mode": "embedding"},
         ]
-        assert utils_gateway.filter_chat_models(items) == ["gpt-4o"]
+        assert utils_gateway.filter_chat_models(items) == [items[0]]
 
 
 class TestLatestHealthByModel:
@@ -82,10 +83,10 @@ class TestDeriveFamily:
 
 class TestFilterByFamily:
     MODELS = [
-        utils_gateway.GatewayModel(name="gpt-4o", family="gpt", health="healthy"),
-        utils_gateway.GatewayModel(name="claude-haiku", family="claude", health="healthy"),
-        utils_gateway.GatewayModel(name="gemini-flash", family="gemini", health="healthy"),
-        utils_gateway.GatewayModel(name="bedrock-qwen3", family=None, health="healthy"),
+        make_gateway_model(name="gpt-4o", family="gpt"),
+        make_gateway_model(name="claude-haiku", family="claude"),
+        make_gateway_model(name="gemini-flash", family="gemini"),
+        make_gateway_model(name="bedrock-qwen3", family=None),
     ]
 
     def test_single_family(self):
@@ -102,8 +103,8 @@ class TestFilterByFamily:
 
 class TestSelectByName:
     MODELS = [
-        utils_gateway.GatewayModel(name="gpt-4o", family="gpt", health="healthy"),
-        utils_gateway.GatewayModel(name="claude-haiku", family="claude", health="unhealthy"),
+        make_gateway_model(name="gpt-4o", family="gpt"),
+        make_gateway_model(name="claude-haiku", family="claude", health="unhealthy"),
     ]
 
     def test_all_found(self):
@@ -123,9 +124,9 @@ class TestSelectByName:
 
 class TestExcludeUnhealthy:
     MODELS = [
-        utils_gateway.GatewayModel(name="gpt-4o", family="gpt", health="healthy"),
-        utils_gateway.GatewayModel(name="claude-haiku", family="claude", health="unhealthy"),
-        utils_gateway.GatewayModel(name="mystery-model", family=None, health="unknown"),
+        make_gateway_model(name="gpt-4o", family="gpt"),
+        make_gateway_model(name="claude-haiku", family="claude", health="unhealthy"),
+        make_gateway_model(name="mystery-model", family=None, health="unknown"),
     ]
 
     def test_drops_unhealthy_keeps_healthy_and_unknown(self):
@@ -136,10 +137,10 @@ class TestExcludeUnhealthy:
 class TestDiscoverChatModels:
     async def test_combines_and_resolves_unfiltered(self, monkeypatch):
         model_group_items = [
-            {"model_group": "gpt-4o", "mode": "chat"},
-            {"model_group": "claude-haiku", "mode": "chat"},
-            {"model_group": "gemini-flash", "mode": "chat"},
-            {"model_group": "mystery-model", "mode": "chat"},
+            {"model_group": "gpt-4o", "mode": "chat", "supports_reasoning": False},
+            {"model_group": "claude-haiku", "mode": "chat", "supports_reasoning": False},
+            {"model_group": "gemini-flash", "mode": "chat", "supports_reasoning": True},
+            {"model_group": "mystery-model", "mode": "chat", "supports_reasoning": False},
             {"model_group": "text-embedding-3", "mode": "embedding"},
         ]
         health_checks = dict(
@@ -174,3 +175,5 @@ class TestDiscoverChatModels:
         assert by_name["gpt-4o"].family == "gpt"
         assert by_name["gemini-flash"].family == "gemini"
         assert by_name["mystery-model"].family is None
+        assert by_name["gemini-flash"].supports_reasoning is True
+        assert by_name["gpt-4o"].supports_reasoning is False

--- a/evals/utils_gateway.py
+++ b/evals/utils_gateway.py
@@ -64,16 +64,26 @@ def filter_by_family(
     return [m for m in models if m.family in family_set]
 
 
-def exclude_unhealthy(models: list[GatewayModel]) -> list[GatewayModel]:
-    """Drop models whose most recent, non-stale health check reports "unhealthy".
+def split_unhealthy(
+    models: list[GatewayModel],
+) -> tuple[list[GatewayModel], list[GatewayModel]]:
+    """Split models into (kept, unhealthy) by most recent, non-stale health check.
 
     Models with no recent health data ("unknown") are kept — absence of
-    evidence isn't evidence of a problem. Kept separate from discovery so
-    callers that want to see everything (e.g. explicit --models lookups,
-    where "confirmed unhealthy" and "unknown model name" need to stay
-    distinguishable) can skip this step.
+    evidence isn't evidence of a problem. Mirrors select_by_name's
+    (found, missing) shape rather than dropping the excluded half silently:
+    callers differ on what to do with `unhealthy` (--models still runs
+    them with a warning; --family/--all drops them and reports it), so
+    both halves need to survive this function, not just the kept one.
     """
-    return [m for m in models if m.health != "unhealthy"]
+    kept = []
+    unhealthy = []
+    for m in models:
+        if m.health == "unhealthy":
+            unhealthy.append(m)
+        else:
+            kept.append(m)
+    return kept, unhealthy
 
 
 def select_by_name(
@@ -173,7 +183,7 @@ async def discover_chat_models() -> list[GatewayModel]:
     """Fetch every chat-capable gateway model with its family and health resolved.
 
     Unfiltered by design — callers decide whether/how to narrow the list
-    (exclude_unhealthy, filter_by_family, or an exact-name lookup), since
+    (split_unhealthy, filter_by_family, or an exact-name lookup), since
     that decision depends on the selection mode (--family/--all/--models).
     """
     async with _gateway_client() as client:

--- a/evals/utils_gateway.py
+++ b/evals/utils_gateway.py
@@ -13,17 +13,14 @@ from datetime import datetime, timedelta, timezone
 
 import httpx
 
-# Health checks run in irregular batches (observed: most within ~48h, a long
-# tail of abandoned models >7 days stale). 72h covers the normal cadence with
-# margin while still treating truly stale entries as unknown, not trusted.
+# Health checks are observed to run within ~48h; 72h gives margin before
+# treating a check as stale.
 STALE_AFTER = timedelta(hours=72)
 
 _FAMILY_SUBSTRINGS = ("claude", "gemini", "locai")
 _GPT_MARKERS = ("gpt", "o4-", "o1-", "o3-")
 
-# Every family derive_family() can return (besides None) — the single source
-# of truth for callers (e.g. benchmark.py's --family choices) that need to
-# validate against "every family we recognise" without duplicating the list.
+# Every family derive_family() can return (besides None).
 KNOWN_FAMILIES = (*_FAMILY_SUBSTRINGS, "gpt")
 
 
@@ -36,13 +33,7 @@ class GatewayModel:
 
 
 def derive_family(name: str) -> str | None:
-    """Bucket a model name into a known vendor family by substring match.
-
-    Only the recognised families (claude/gemini/locai/gpt) are classified.
-    Everything else returns None rather than a guessed catch-all bucket —
-    the leftover models span unrelated architectures/vendors, so grouping
-    them under one label would imply a relationship that isn't there.
-    """
+    """Bucket a model name into a known vendor family (claude/gemini/locai/gpt) by substring match."""
     lowered = name.lower()
     for family in _FAMILY_SUBSTRINGS:
         if family in lowered:
@@ -55,11 +46,7 @@ def derive_family(name: str) -> str | None:
 def filter_by_family(
     models: list[GatewayModel], families: list[str]
 ) -> list[GatewayModel]:
-    """Return models whose family matches any of the given families.
-
-    Takes a list so callers can compare multiple families in one run
-    (e.g. gemini vs. claude), not just select a single one.
-    """
+    """Return models whose family matches any of the given families."""
     family_set = set(families)
     return [m for m in models if m.family in family_set]
 
@@ -70,11 +57,7 @@ def split_unhealthy(
     """Split models into (kept, unhealthy) by most recent, non-stale health check.
 
     Models with no recent health data ("unknown") are kept — absence of
-    evidence isn't evidence of a problem. Mirrors select_by_name's
-    (found, missing) shape rather than dropping the excluded half silently:
-    callers differ on what to do with `unhealthy` (--models still runs
-    them with a warning; --family/--all drops them and reports it), so
-    both halves need to survive this function, not just the kept one.
+    evidence isn't evidence of a problem.
     """
     kept = []
     unhealthy = []
@@ -89,14 +72,7 @@ def split_unhealthy(
 def select_by_name(
     models: list[GatewayModel], names: list[str]
 ) -> tuple[list[GatewayModel], list[str]]:
-    """Split requested names into found models and names not on the gateway.
-
-    Unlike --family (a fixed, argparse-validated choice set), model names
-    come from whatever's currently on the gateway, so a typo can only be
-    caught by looking it up at runtime. Returns plain data — callers decide
-    how to report `missing` (error, warning, etc.), keeping that a CLI
-    concern rather than something this module prints itself.
-    """
+    """Split requested names into found models and names not on the gateway."""
     by_name = {m.name: m for m in models}
     found = []
     missing = []
@@ -182,9 +158,8 @@ async def fetch_health_latest(client: httpx.AsyncClient) -> dict[str, dict]:
 async def discover_chat_models() -> list[GatewayModel]:
     """Fetch every chat-capable gateway model with its family and health resolved.
 
-    Unfiltered by design — callers decide whether/how to narrow the list
-    (split_unhealthy, filter_by_family, or an exact-name lookup), since
-    that decision depends on the selection mode (--family/--all/--models).
+    Unfiltered by design — callers narrow the list themselves (split_unhealthy,
+    filter_by_family, or an exact-name lookup) based on how they want to select.
     """
     async with _gateway_client() as client:
         model_group_items, health_checks = await asyncio.gather(

--- a/evals/utils_gateway.py
+++ b/evals/utils_gateway.py
@@ -21,12 +21,18 @@ STALE_AFTER = timedelta(hours=72)
 _FAMILY_SUBSTRINGS = ("claude", "gemini", "locai")
 _GPT_MARKERS = ("gpt", "o4-", "o1-", "o3-")
 
+# Every family derive_family() can return (besides None) — the single source
+# of truth for callers (e.g. benchmark.py's --family choices) that need to
+# validate against "every family we recognise" without duplicating the list.
+KNOWN_FAMILIES = (*_FAMILY_SUBSTRINGS, "gpt")
+
 
 @dataclass(frozen=True)
 class GatewayModel:
     name: str
     family: str | None
     health: str  # "healthy" | "unhealthy" | "unknown"
+    supports_reasoning: bool = False
 
 
 def derive_family(name: str) -> str | None:
@@ -90,9 +96,13 @@ def select_by_name(
     return found, missing
 
 
-def filter_chat_models(model_group_items: list[dict]) -> list[str]:
-    """Return model_group names that support chat completions."""
-    return [item["model_group"] for item in model_group_items if item.get("mode") == "chat"]
+def filter_chat_models(model_group_items: list[dict]) -> list[dict]:
+    """Return model_group entries that support chat completions.
+
+    Keeps the raw dicts, not just names, so callers can still read
+    per-model fields like `supports_reasoning`.
+    """
+    return [item for item in model_group_items if item.get("mode") == "chat"]
 
 
 def _parse_checked_at(value: str) -> datetime:
@@ -168,14 +178,15 @@ async def discover_chat_models() -> list[GatewayModel]:
             fetch_health_latest(client),
         )
 
-    chat_names = filter_chat_models(model_group_items)
+    chat_models = filter_chat_models(model_group_items)
     health_by_name = latest_health_by_model(health_checks)
 
     return [
         GatewayModel(
-            name=name,
-            family=derive_family(name),
-            health=health_by_name.get(name, "unknown"),
+            name=item["model_group"],
+            family=derive_family(item["model_group"]),
+            health=health_by_name.get(item["model_group"], "unknown"),
+            supports_reasoning=item["supports_reasoning"],
         )
-        for name in chat_names
+        for item in chat_models
     ]

--- a/evals/utils_gateway.py
+++ b/evals/utils_gateway.py
@@ -52,7 +52,9 @@ def derive_family(name: str) -> str | None:
     return None
 
 
-def filter_by_family(models: list[GatewayModel], families: list[str]) -> list[GatewayModel]:
+def filter_by_family(
+    models: list[GatewayModel], families: list[str]
+) -> list[GatewayModel]:
     """Return models whose family matches any of the given families.
 
     Takes a list so callers can compare multiple families in one run
@@ -145,7 +147,9 @@ def _gateway_client() -> httpx.AsyncClient:
     base_url = os.getenv("LLM_GATEWAY_URL")
     api_key = os.getenv("CONSULT_EVAL_LITELLM_API_KEY")
     if not base_url or not api_key:
-        raise RuntimeError("LLM_GATEWAY_URL and CONSULT_EVAL_LITELLM_API_KEY must be set")
+        raise RuntimeError(
+            "LLM_GATEWAY_URL and CONSULT_EVAL_LITELLM_API_KEY must be set"
+        )
     return httpx.AsyncClient(
         base_url=base_url.rstrip("/"),
         headers={"Authorization": f"Bearer {api_key}"},

--- a/evals/utils_gateway.py
+++ b/evals/utils_gateway.py
@@ -129,13 +129,19 @@ def latest_health_by_model(
     }
 
 
-def _gateway_client() -> httpx.AsyncClient:
+def gateway_credentials() -> tuple[str, str]:
+    """Read and validate the two required gateway env vars."""
     base_url = os.getenv("LLM_GATEWAY_URL")
     api_key = os.getenv("CONSULT_EVAL_LITELLM_API_KEY")
     if not base_url or not api_key:
         raise RuntimeError(
             "LLM_GATEWAY_URL and CONSULT_EVAL_LITELLM_API_KEY must be set"
         )
+    return base_url, api_key
+
+
+def _gateway_client() -> httpx.AsyncClient:
+    base_url, api_key = gateway_credentials()
     return httpx.AsyncClient(
         base_url=base_url.rstrip("/"),
         headers={"Authorization": f"Bearer {api_key}"},

--- a/evals/utils_gateway.py
+++ b/evals/utils_gateway.py
@@ -46,6 +46,50 @@ def derive_family(name: str) -> str | None:
     return None
 
 
+def filter_by_family(models: list[GatewayModel], families: list[str]) -> list[GatewayModel]:
+    """Return models whose family matches any of the given families.
+
+    Takes a list so callers can compare multiple families in one run
+    (e.g. gemini vs. claude), not just select a single one.
+    """
+    family_set = set(families)
+    return [m for m in models if m.family in family_set]
+
+
+def exclude_unhealthy(models: list[GatewayModel]) -> list[GatewayModel]:
+    """Drop models whose most recent, non-stale health check reports "unhealthy".
+
+    Models with no recent health data ("unknown") are kept — absence of
+    evidence isn't evidence of a problem. Kept separate from discovery so
+    callers that want to see everything (e.g. explicit --models lookups,
+    where "confirmed unhealthy" and "unknown model name" need to stay
+    distinguishable) can skip this step.
+    """
+    return [m for m in models if m.health != "unhealthy"]
+
+
+def select_by_name(
+    models: list[GatewayModel], names: list[str]
+) -> tuple[list[GatewayModel], list[str]]:
+    """Split requested names into found models and names not on the gateway.
+
+    Unlike --family (a fixed, argparse-validated choice set), model names
+    come from whatever's currently on the gateway, so a typo can only be
+    caught by looking it up at runtime. Returns plain data — callers decide
+    how to report `missing` (error, warning, etc.), keeping that a CLI
+    concern rather than something this module prints itself.
+    """
+    by_name = {m.name: m for m in models}
+    found = []
+    missing = []
+    for name in names:
+        if name in by_name:
+            found.append(by_name[name])
+        else:
+            missing.append(name)
+    return found, missing
+
+
 def filter_chat_models(model_group_items: list[dict]) -> list[str]:
     """Return model_group names that support chat completions."""
     return [item["model_group"] for item in model_group_items if item.get("mode") == "chat"]
@@ -112,11 +156,11 @@ async def fetch_health_latest(client: httpx.AsyncClient) -> dict[str, dict]:
 
 
 async def discover_chat_models() -> list[GatewayModel]:
-    """Fetch and combine gateway model info into the eval-ready model list.
+    """Fetch every chat-capable gateway model with its family and health resolved.
 
-    Excludes only models whose most recent, non-stale health check reports
-    "unhealthy". Models with no recent health data are included as
-    "unknown" — absence of evidence isn't evidence of a problem.
+    Unfiltered by design — callers decide whether/how to narrow the list
+    (exclude_unhealthy, filter_by_family, or an exact-name lookup), since
+    that decision depends on the selection mode (--family/--all/--models).
     """
     async with _gateway_client() as client:
         model_group_items, health_checks = await asyncio.gather(
@@ -128,7 +172,10 @@ async def discover_chat_models() -> list[GatewayModel]:
     health_by_name = latest_health_by_model(health_checks)
 
     return [
-        GatewayModel(name=name, family=derive_family(name), health=health)
+        GatewayModel(
+            name=name,
+            family=derive_family(name),
+            health=health_by_name.get(name, "unknown"),
+        )
         for name in chat_names
-        if (health := health_by_name.get(name, "unknown")) != "unhealthy"
     ]

--- a/evals/utils_gateway.py
+++ b/evals/utils_gateway.py
@@ -1,0 +1,134 @@
+"""Discover chat-capable models available on the LLM gateway.
+
+Combines /model_group/info (which models exist and support chat) with
+/health/latest (whether they're currently reachable) into the model list
+the eval suite runs against, so it updates automatically as the gateway's
+model list changes.
+"""
+
+import asyncio
+import os
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+import httpx
+
+# Health checks run in irregular batches (observed: most within ~48h, a long
+# tail of abandoned models >7 days stale). 72h covers the normal cadence with
+# margin while still treating truly stale entries as unknown, not trusted.
+STALE_AFTER = timedelta(hours=72)
+
+_FAMILY_SUBSTRINGS = ("claude", "gemini", "locai")
+_GPT_MARKERS = ("gpt", "o4-", "o1-", "o3-")
+
+
+@dataclass(frozen=True)
+class GatewayModel:
+    name: str
+    family: str | None
+    health: str  # "healthy" | "unhealthy" | "unknown"
+
+
+def derive_family(name: str) -> str | None:
+    """Bucket a model name into a known vendor family by substring match.
+
+    Only the recognised families (claude/gemini/locai/gpt) are classified.
+    Everything else returns None rather than a guessed catch-all bucket —
+    the leftover models span unrelated architectures/vendors, so grouping
+    them under one label would imply a relationship that isn't there.
+    """
+    lowered = name.lower()
+    for family in _FAMILY_SUBSTRINGS:
+        if family in lowered:
+            return family
+    if any(marker in lowered for marker in _GPT_MARKERS):
+        return "gpt"
+    return None
+
+
+def filter_chat_models(model_group_items: list[dict]) -> list[str]:
+    """Return model_group names that support chat completions."""
+    return [item["model_group"] for item in model_group_items if item.get("mode") == "chat"]
+
+
+def _parse_checked_at(value: str) -> datetime:
+    """Parse a health-check timestamp, tolerating naive values and 'Z' suffixes."""
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def latest_health_by_model(
+    health_checks: dict[str, dict],
+    now: datetime | None = None,
+    stale_after: timedelta = STALE_AFTER,
+) -> dict[str, str]:
+    """Reduce raw health-check rows to one status per model name.
+
+    Keeps the most recent check per model name; a check older than
+    `stale_after` is dropped (that row, not the model) rather than trusted
+    as current status.
+    """
+    now = now or datetime.now(timezone.utc)
+    latest: dict[str, tuple[datetime, str]] = {}  # name -> (checked_at, status)
+
+    for check in health_checks.values():
+        name = check["model_name"]
+        checked_at = _parse_checked_at(check["checked_at"])
+        if name in latest and checked_at <= latest[name][0]:
+            continue
+        latest[name] = (checked_at, check["status"])
+
+    return {
+        name: status
+        for name, (checked_at, status) in latest.items()
+        if now - checked_at <= stale_after
+    }
+
+
+def _gateway_client() -> httpx.AsyncClient:
+    base_url = os.getenv("LLM_GATEWAY_URL")
+    api_key = os.getenv("CONSULT_EVAL_LITELLM_API_KEY")
+    if not base_url or not api_key:
+        raise RuntimeError("LLM_GATEWAY_URL and CONSULT_EVAL_LITELLM_API_KEY must be set")
+    return httpx.AsyncClient(
+        base_url=base_url.rstrip("/"),
+        headers={"Authorization": f"Bearer {api_key}"},
+        timeout=30,
+    )
+
+
+async def fetch_model_group_info(client: httpx.AsyncClient) -> list[dict]:
+    response = await client.get("/model_group/info")
+    response.raise_for_status()
+    return response.json()["data"]
+
+
+async def fetch_health_latest(client: httpx.AsyncClient) -> dict[str, dict]:
+    response = await client.get("/health/latest")
+    response.raise_for_status()
+    return response.json()["latest_health_checks"]
+
+
+async def discover_chat_models() -> list[GatewayModel]:
+    """Fetch and combine gateway model info into the eval-ready model list.
+
+    Excludes only models whose most recent, non-stale health check reports
+    "unhealthy". Models with no recent health data are included as
+    "unknown" — absence of evidence isn't evidence of a problem.
+    """
+    async with _gateway_client() as client:
+        model_group_items, health_checks = await asyncio.gather(
+            fetch_model_group_info(client),
+            fetch_health_latest(client),
+        )
+
+    chat_names = filter_chat_models(model_group_items)
+    health_by_name = latest_health_by_model(health_checks)
+
+    return [
+        GatewayModel(name=name, family=derive_family(name), health=health)
+        for name in chat_names
+        if (health := health_by_name.get(name, "unknown")) != "unhealthy"
+    ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
 ]
 dependencies = [
     "openai>=1.0.0",
+    "httpx>=0.23.0",
     "pandas>=2.2.2",
     "python-dotenv>=1.0.1",
     "langfuse>=3.12.1",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10, <3.13"
 resolution-markers = [
     "python_full_version >= '3.12' and sys_platform == 'win32'",
@@ -334,7 +334,7 @@ name = "cuda-bindings"
 version = "12.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/d8/b546104b8da3f562c1ff8ab36d130c8fe1dd6a045ced80b4f6ad74f7d4e1/cuda_bindings-12.9.4-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d3c842c2a4303b2a580fe955018e31aea30278be19795ae05226235268032e5", size = 12148218, upload-time = "2025-10-21T14:51:28.855Z" },
@@ -373,7 +373,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1016,7 +1016,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-cublas-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -1027,7 +1027,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -1054,9 +1054,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "nvidia-cusparse-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "nvidia-nvjitlink-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cusparse-cu12" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -1067,7 +1067,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -1252,10 +1252,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
-    { name = "pytz", marker = "python_full_version < '3.11'" },
-    { name = "tzdata", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -1295,9 +1295,9 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
-    { name = "tzdata", marker = "(python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/de/da/b1dc0481ab8d55d0f46e343cfe67d4551a0e14fcee52bd38ca1bd73258d8/pandas-3.0.0.tar.gz", hash = "sha256:0facf7e87d38f721f0af46fe70d97373a37701b1c09f7ed7aeeb292ade5c050f", size = 4633005, upload-time = "2026-01-21T15:52:04.726Z" }
 wheels = [
@@ -1753,10 +1753,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "joblib", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "threadpoolctl", marker = "python_full_version < '3.11'" },
+    { name = "joblib" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "threadpoolctl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/c2/a7855e41c9d285dfe86dc50b250978105dce513d6e459ea66a6aeb0e1e0c/scikit_learn-1.7.2.tar.gz", hash = "sha256:20e9e49ecd130598f1ca38a1d85090e1a600147b9c02fa6f15d69cb53d968fda", size = 7193136, upload-time = "2025-09-09T08:21:29.075Z" }
 wheels = [
@@ -1790,10 +1790,10 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "joblib", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "threadpoolctl", marker = "python_full_version >= '3.11'" },
+    { name = "joblib" },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "threadpoolctl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/40988bf3b8e34feec1d0e6a051446b1f66225f8529b9309becaeef62b6c4/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd", size = 7335585, upload-time = "2025-12-10T07:08:53.618Z" }
 wheels = [
@@ -1819,7 +1819,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -1865,7 +1865,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/56/3e/9cca699f3486ce6bc12ff46dc2031f1ec8eb9ccc9a320fdaf925f1417426/scipy-1.17.0.tar.gz", hash = "sha256:2591060c8e648d8b96439e111ac41fd8342fdeff1876be2e19dea3fe8930454e", size = 30396830, upload-time = "2026-01-10T21:34:23.009Z" }
 wheels = [
@@ -1977,6 +1977,7 @@ source = { editable = "." }
 dependencies = [
     { name = "boto3" },
     { name = "cryptography" },
+    { name = "httpx" },
     { name = "langfuse" },
     { name = "nest-asyncio" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -2015,6 +2016,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.29" },
     { name = "coverage", marker = "extra == 'dev'", specifier = ">=7.6.10" },
     { name = "cryptography", specifier = ">=46.0.7" },
+    { name = "httpx", specifier = ">=0.23.0" },
     { name = "langfuse", specifier = ">=3.12.1" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.6.1" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5.50" },


### PR DESCRIPTION
## Why

Model access should be allowed only through the central i.AI LLM gateway (LiteLLM). This PR makes that true everywhere in this repo — evals, synthetic data generation, and the benchmark CLI — and replaces the hardcoded model list with one that updates automatically as the gateway's model list changes.

## What changed

### Dynamic model discovery (new)

`evals/utils_gateway.py` fetches the gateway's `/model_group/info` and `/health/latest` and turns them into a list of chat-capable models, each with vendor family and health resolved. Filtering is composable (`split_unhealthy`, `filter_by_family`, `select_by_name`) so callers — not this module — decide what to do with unhealthy or unknown matches.

### `benchmark.py` — no more hardcoded model list

The old `MODEL_REGISTRY` (Azure/Vertex/locai) is gone, along with the Vertex code path (it never worked — `create_llm()` unconditionally raised `NotImplementedError` for it). Instead relevant models are found dynamically by querying the gateway.

| Before | After |
|---|---|
| `--provider {azure,vertex,locai,all}` | `--models <name>...` / `--family {gpt,claude,gemini,locai}...` / `--all` (exactly one required) |
| `reasoning_effort` hardcoded per model name; no way to sweep effort levels | Creates a separate config per effort level by sweeping `--reasoning-effort {low,medium,high}...` across all models whose `supports_reasoning` flag, read from the gateway, is true |

Model selection (`--models` vs. `--family`/`--all`) is two small functions, `_select_named_models`/`_select_healthy_models`, each returning only the fields relevant to its own mode — `--models` warns on unhealthy matches but still runs them (explicit request by name); `--family`/`--all` drops unhealthy matches and reports what was dropped.

### Synthetic data generation — off direct Azure

`evals/synthetic/*` now talks to the gateway (`openai.AsyncOpenAI(base_url=LLM_GATEWAY_URL, ...)`) instead of constructing an `AsyncAzureOpenAI` client directly. The two models it uses are now named constants (`DRAFTING_MODEL`, `RESPONSE_GENERATION_MODEL`) instead of repeated string literals.

### Gateway credentials — one source of truth

`LLM_GATEWAY_URL`/`CONSULT_EVAL_LITELLM_API_KEY` were each read directly via `os.getenv` in 10 separate places across `benchmark.py`, `metrics.py`, all four `eval_*.py` files, `synthetic/cli.py`, and `generate_synthetic.py` — only `utils_gateway.py`'s own client validated them before use; everywhere else silently passed `None`/`None` into `OpenAILLM`/`AsyncOpenAI` on a misconfigured environment. Added `utils_gateway.gateway_credentials()` as the single source of truth; every call site now gets the same fail-fast validation.

### Config cleanup

`.env.example` and `eval.yml` no longer list `AZURE_OPENAI_*`/`GOOGLE_CLOUD_*`/`LOCAI_*` — confirmed unused anywhere in the repo post-migration. `LLM_GATEWAY_URL`/`CONSULT_EVAL_LITELLM_API_KEY` are documented (previously required but missing from `.env.example`). `AUTO_EVAL_4_1_SWEDEN_DEPLOYMENT` (read by the eval judge/scoring path) is now prefilled with a known-working value plus a TODO, instead of being left blank and failing with a confusing 400 partway through a run.

### Tests

35 tests (`test_utils_gateway.py`, `test_benchmark.py`) covering the discovery and selection logic against mocked gateway responses.

## Test plan

Verified live against the real gateway:
- [x] `benchmark.py --quick` runs end-to-end
- [x] `benchmark.py --models gpt-4.1-nano-sweden --evals mapping` runs and returns real scores
- [x] `benchmark.py --family locai --evals mapping` — selection/execution mechanism confirmed working (discovered, filtered to family, excluded the unhealthy match, ran the rest); the eval itself failed for an unrelated, pre-existing reason (locai's structured-output handling), not a regression from this PR
- [x] `benchmark.py` with no selector errors as expected (exit 2)
- [x] `generate_synthetic.py` runs end-to-end (1 question, 10 responses) — verified real output on disk
- [x] All 35 unit tests pass
- [x] `pre-commit` clean (`ruff`, `ruff format`, secret/IP/AWS-key scans, nbstripout)

Not yet verified:
- [ ] `benchmark.py --models <unhealthy-name>` through a full run (the warn-but-still-run behavior is unit-tested; no currently-unhealthy model was available on the live gateway to exercise it end-to-end)
- [ ] CI (`eval.yml`, `pre-commit.yml`) on this actual PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
